### PR TITLE
New Utils dir for the container runtime benchmarks. 

### DIFF
--- a/src/container-runtime/utils/Dockerfile.base
+++ b/src/container-runtime/utils/Dockerfile.base
@@ -1,0 +1,86 @@
+##################################################################################################
+# OCP SRV CMS - Base Container Image (Dockerfile.base)
+#
+# Shared base image for all CMS benchmark containers. Provides:
+#   - Ubuntu 24.04 LTS (Noble) base
+#   - System BOM collection tools (dmidecode, lm-sensors, ethtool, ipmitool, etc.)
+#   - CXL and NUMA tooling (cxl, numactl, libnuma-dev)
+#   - Build toolchain (gcc, make, etc.)
+#   - Python 3 runtime
+#   - Common utilities (bc, pciutils, util-linux, etc.)
+#   - The cms_common.sh library, collect_sysinfo.sh, and generate_report.sh at /opt/cms-utils/
+#
+# Individual benchmark Dockerfiles should:
+#   FROM ocp-cms-base:latest
+#   ... add benchmark-specific packages and build steps ...
+#
+# Build:
+#   docker build -t ocp-cms-base:latest -f Dockerfile.base .
+##################################################################################################
+
+FROM ubuntu:24.04
+
+LABEL maintainer="OCP SRV CMS Benchmarks"
+LABEL description="Base image for OCP CMS benchmark containers"
+LABEL version="0.1.0"
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install all packages needed across benchmarks, organized by purpose
+RUN apt-get update && apt-get install -y \
+    #--- Core utilities ---
+    wget \
+    curl \
+    tar \
+    gzip \
+    bc \
+    jq \
+    util-linux \
+    procps \
+    coreutils \
+    #--- Build toolchain ---
+    build-essential \
+    gcc \
+    g++ \
+    make \
+    cmake \
+    automake \
+    autoconf \
+    libtool \
+    pkg-config \
+    #--- NUMA / CXL ---
+    numactl \
+    libnuma-dev \
+    cxl \
+    #--- Hardware inspection / BOM collection ---
+    dmidecode \
+    pciutils \
+    ipmitool \
+    lm-sensors \
+    ethtool \
+    net-tools \
+    iproute2 \
+    lsb-release \
+    sysstat \
+    lvm2 \
+    #--- Python ---
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create the shared utils directory
+RUN mkdir -p /opt/cms-utils
+
+# Copy in the shared scripts
+COPY collect_sysinfo.sh  /opt/cms-utils/collect_sysinfo.sh
+COPY cms_common.sh       /opt/cms-utils/cms_common.sh
+COPY generate_report.sh  /opt/cms-utils/generate_report.sh
+
+# Make them executable
+RUN chmod +x /opt/cms-utils/collect_sysinfo.sh \
+    && chmod +x /opt/cms-utils/cms_common.sh \
+    && chmod +x /opt/cms-utils/generate_report.sh
+
+# Set a default working directory (benchmarks override this)
+WORKDIR /opt/benchmark

--- a/src/container-runtime/utils/README.md
+++ b/src/container-runtime/utils/README.md
@@ -1,1 +1,169 @@
-This is where the container runtime base goes, and where all the utils for system info gathering and output generation live. 
+# OCP SRV CMS - Container Runtime Utilities
+
+This directory contains shared utilities for all CMS benchmark containers. Every benchmark container (hardware and software) should pull from these common scripts to ensure consistent system information collection, logging, and output generation.
+
+## Contents
+
+| File                  | Type       | Description |
+|:----------------------|:-----------|:------------|
+| `Dockerfile.base`     | Dockerfile | Shared base image with all common packages. Benchmark Dockerfiles `FROM ocp-cms-base:latest`. |
+| `cms_common.sh`       | Library    | Sourceable shell library providing logging, timing, NUMA/CPU topology queries, hugepage/governor management, unit conversion, and report generation. |
+| `collect_sysinfo.sh`  | Script     | Standalone system BOM collector. Dumps comprehensive hardware and software inventory into a categorized directory tree. |
+| `generate_report.sh`  | Script     | Post-run report generator. Produces an HTML report and results tarball from benchmark output. |
+
+## How Benchmarks Integrate
+
+### 1. Build the base image (one time)
+
+```bash
+cd src/container-runtime/utils
+docker build -t ocp-cms-base:latest -f Dockerfile.base .
+```
+
+### 2. Benchmark Dockerfiles inherit from the base
+
+```dockerfile
+FROM ocp-cms-base:latest
+
+# Benchmark-specific packages
+RUN apt-get update && apt-get install -y memcached && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/memcached-bench
+COPY run_memcached.sh  /opt/memcached-bench/run_memcached.sh
+COPY entrypoint.sh     /opt/memcached-bench/entrypoint.sh
+RUN chmod +x *.sh
+
+ENTRYPOINT ["./entrypoint.sh"]
+```
+
+If a benchmark cannot use the base image (e.g. it needs a different distro), it should instead COPY the utils scripts directly:
+
+```dockerfile
+FROM ubuntu:24.04
+# ... install packages ...
+COPY ../utils/collect_sysinfo.sh  /opt/cms-utils/collect_sysinfo.sh
+COPY ../utils/cms_common.sh       /opt/cms-utils/cms_common.sh
+COPY ../utils/generate_report.sh  /opt/cms-utils/generate_report.sh
+RUN chmod +x /opt/cms-utils/*.sh
+```
+
+### 3. Benchmark run scripts source the common library
+
+```bash
+#!/usr/bin/env bash
+
+# Source the common library
+source /opt/cms-utils/cms_common.sh
+
+# Set benchmark identity
+CMS_SCRIPT_NAME="memcached-bench"
+CMS_VERSION="0.1.0"
+
+# Trap Ctrl-C
+cms_trap_ctrlc
+
+# Initialize outputs
+cms_init_outputs
+
+# Capture all stdout/stderr to a log file
+cms_log_stdout_stderr
+
+# Display start banner
+cms_display_start_info "$*"
+
+# Collect system BOM
+cms_collect_sysinfo
+
+# Query the platform topology
+cms_query_topology
+
+# ... run the benchmark ...
+cms_log_info "Starting benchmark..."
+
+# Generate report (HTML + tarball)
+cms_generate_report ./results memcached ./results/results.csv
+
+# Display end banner
+cms_display_end_info
+
+# Package results
+cms_package_results
+```
+
+## System Information Collected by collect_sysinfo.sh
+
+The collector creates the following directory structure:
+
+```
+sysinfo/
+├── SUMMARY.txt                  # Human-readable one-page overview
+├── collection_metadata.txt      # Timestamp, hostname, container ID
+├── bios_firmware/               # dmidecode tables, DMI sysfs fields
+│   ├── dmidecode_full.txt
+│   ├── dmidecode_bios.txt
+│   ├── dmidecode_memory.txt
+│   ├── dmi_product_name.txt
+│   └── ...
+├── cpu/                         # lscpu, /proc/cpuinfo, frequencies, governor,
+│   ├── lscpu.txt                  cache topology, vulnerabilities, microcode
+│   ├── cpuinfo.txt
+│   ├── cache_topology.txt
+│   ├── all_cpu_frequencies.txt
+│   └── ...
+├── memory/                      # /proc/meminfo, free, hugepages, VM tunables,
+│   ├── meminfo.txt                buddyinfo, zoneinfo, vmstat, slabinfo
+│   ├── nr_hugepages.txt
+│   ├── thp_enabled.txt
+│   └── ...
+├── numa_cxl/                    # numactl, per-node meminfo/cpulist/distance,
+│   ├── numactl_hardware.txt       CXL device list, sysfs tree, distance matrix,
+│   ├── cxl_list_all.txt           DIMM topology table
+│   ├── memory_topology.txt
+│   ├── node0/
+│   │   ├── meminfo.txt
+│   │   ├── cpulist.txt
+│   │   └── distance.txt
+│   └── ...
+├── pci_devices/                 # lspci plain, verbose, tree, numeric, kernel
+├── network/                     # ip addr/link/route, ethtool, ss
+├── storage/                     # lsblk, df, mount, LVM, /proc/partitions
+├── kernel_os/                   # uname, os-release, modules, kernel config,
+│   ├── cmdline.txt                sysctl dump, key CMS tunables, interrupts,
+│   ├── key_tunables.txt           security module status
+│   └── ...
+├── packages/                    # dpkg/rpm package lists, pip packages,
+│   ├── dpkg_list.txt              shared libraries, tool versions, libc
+│   ├── tool_versions.txt
+│   └── ...
+├── runtime/                     # Container environment, cgroup v1/v2 limits,
+│   ├── environment.txt            process limits, ulimit
+│   └── ...
+├── gpu/                         # nvidia-smi, rocm-smi (if present)
+└── power/                       # lm-sensors, thermal zones, RAPL counters, IPMI
+```
+
+## Functions Provided by cms_common.sh
+
+### Logging
+`cms_log_info`, `cms_log_warn`, `cms_log_error`, `cms_log_debug`
+
+### Output Management
+`cms_init_outputs`, `cms_log_stdout_stderr`, `cms_package_results`
+
+### Banners
+`cms_display_start_info`, `cms_display_end_info`
+
+### Topology Queries
+`cms_query_topology` (all-in-one), `cms_get_num_sockets`, `cms_get_cores_per_socket`, `cms_get_threads_per_core`, `cms_get_numa_node_count`, `cms_get_cxl_device_count`, `cms_check_hyperthreading`, `cms_get_cpulist_for_node`, `cms_get_first_cpu_on_node`, `cms_get_memory_per_node`
+
+### Validation
+`cms_verify_cmds`, `cms_verify_numa_node`, `cms_verify_socket`
+
+### System Tuning
+`cms_set_performance_governor` / `cms_restore_governor`, `cms_set_hugepages` / `cms_restore_hugepages`, `cms_clear_page_cache`
+
+### Collection & Reporting
+`cms_collect_sysinfo`, `cms_generate_report`
+
+### Utilities
+`cms_to_bytes`, `cms_trap_ctrlc`

--- a/src/container-runtime/utils/cms_common.sh
+++ b/src/container-runtime/utils/cms_common.sh
@@ -1,0 +1,465 @@
+#!/usr/bin/env bash
+
+#################################################################################################
+# OCP SRV CMS - Common Benchmark Library (cms_common.sh)
+#
+# Sourceable shell library providing shared functions for all CMS benchmark containers.
+# Unifies patterns currently duplicated across mlc.sh, run-stream-scaling.sh, and lib/common.
+#
+# Usage: source /opt/cms-utils/cms_common.sh
+#
+# This file is COPY'd into every benchmark container at /opt/cms-utils/ and sourced by
+# each benchmark's run script. It provides:
+#
+#   - Logging (info, warn, error, debug with timestamps)
+#   - Output directory initialization and log capture
+#   - Start/end banners with elapsed time
+#   - System topology queries (sockets, cores, NUMA, CXL, hyperthreading)
+#   - System info collection (calls collect_sysinfo.sh)
+#   - Utility functions (convert units, verify commands, page cache, etc.)
+#################################################################################################
+
+CMS_COMMON_VERSION="0.1.0"
+
+# Guard against double-sourcing
+if [ -n "${_CMS_COMMON_LOADED:-}" ]; then
+    return 0 2>/dev/null || true
+fi
+_CMS_COMMON_LOADED=1
+
+#################################################################################################
+# Script identity (set by the calling script, defaults provided here)
+#################################################################################################
+
+CMS_SCRIPT_NAME="${CMS_SCRIPT_NAME:-${0##*/}}"
+CMS_SCRIPT_DIR="${CMS_SCRIPT_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[1]:-$0}")" &>/dev/null && pwd 2>/dev/null)}"
+CMS_VERSION="${CMS_VERSION:-0.0.0}"
+
+#################################################################################################
+# Output paths
+#################################################################################################
+
+CMS_OUTPUT_PATH="${CMS_OUTPUT_PATH:-./${CMS_SCRIPT_NAME}.$(hostname).$(date +"%m%d-%H%M")}"
+CMS_LOG_FILE=""    # Set by cms_log_stdout_stderr
+
+#################################################################################################
+# 1. Logging
+#################################################################################################
+
+cms_log_info()  { echo "[INFO]  $(date '+%Y-%m-%d %H:%M:%S') - $*"; }
+cms_log_warn()  { echo "[WARN]  $(date '+%Y-%m-%d %H:%M:%S') - $*"; }
+cms_log_error() { echo "[ERROR] $(date '+%Y-%m-%d %H:%M:%S') - $*" >&2; }
+cms_log_debug() {
+    if [ "${CMS_VERBOSITY:-0}" -ge 1 ]; then
+        echo "[DEBUG] $(date '+%Y-%m-%d %H:%M:%S') - ${BASH_SOURCE[1]##*/}:${FUNCNAME[1]}[${BASH_LINENO[0]}] $*"
+    fi
+}
+
+#################################################################################################
+# 2. Output directory & log capture
+#################################################################################################
+
+# Create the output directory. Removes any stale one first.
+cms_init_outputs() {
+    rm -rf "${CMS_OUTPUT_PATH}" 2>/dev/null
+    mkdir -p "${CMS_OUTPUT_PATH}"
+    cms_log_info "Output directory: ${CMS_OUTPUT_PATH}"
+}
+
+# Tee all stdout+stderr to a log file inside the output directory.
+# Call AFTER cms_init_outputs.
+cms_log_stdout_stderr() {
+    local log_path="${1:-${CMS_OUTPUT_PATH}}"
+    CMS_LOG_FILE="${log_path}/${CMS_SCRIPT_NAME}.log"
+    local tee_cmd
+    tee_cmd=$(command -v tee 2>/dev/null)
+    if [ -n "${tee_cmd}" ]; then
+        exec &> >(${tee_cmd} -a "${CMS_LOG_FILE}")
+    else
+        exec &> "${CMS_LOG_FILE}"
+    fi
+}
+
+#################################################################################################
+# 3. Start / End Banners
+#################################################################################################
+
+_CMS_START_TIME=0
+
+cms_display_start_info() {
+    _CMS_START_TIME=$(date +%s)
+    echo "======================================================================="
+    echo "Starting ${CMS_SCRIPT_NAME}"
+    echo "${CMS_SCRIPT_NAME} Version ${CMS_VERSION}"
+    echo "CMS Common Library Version ${CMS_COMMON_VERSION}"
+    if [ -n "$1" ]; then
+        echo "Arguments: $*"
+    fi
+    echo "Started: $(date --date "@${_CMS_START_TIME}" 2>/dev/null || date)"
+    echo "======================================================================="
+}
+
+cms_display_end_info() {
+    local end_time
+    end_time=$(date +%s)
+    local duration=$(( end_time - _CMS_START_TIME ))
+
+    local days=$(( duration / 86400 ))
+    local hours=$(( (duration % 86400) / 3600 ))
+    local minutes=$(( (duration % 3600) / 60 ))
+    local seconds=$(( duration % 60 ))
+
+    local result=""
+    [ $days    -gt 0 ] && result+="${days} day(s), "
+    [ $hours   -gt 0 ] && result+="${hours} hour(s), "
+    [ $minutes -gt 0 ] && result+="${minutes} minute(s), "
+    result+="${seconds} second(s)"
+
+    echo "======================================================================="
+    echo "${CMS_SCRIPT_NAME} Completed"
+    echo "Ended: $(date --date "@${end_time}" 2>/dev/null || date)"
+    echo "Duration: ${result}"
+    echo "Results: ${CMS_OUTPUT_PATH}"
+    [ -n "${CMS_LOG_FILE}" ] && echo "Logfile: ${CMS_LOG_FILE}"
+    echo "======================================================================="
+}
+
+#################################################################################################
+# 4. Ctrl-C Handler
+#################################################################################################
+
+cms_trap_ctrlc() {
+    trap '_cms_ctrlc_handler' INT
+}
+
+_cms_ctrlc_handler() {
+    echo ""
+    cms_log_info "Received CTRL+C - aborting"
+    cms_display_end_info
+    exit 1
+}
+
+#################################################################################################
+# 5. Command Verification
+#################################################################################################
+
+# Verify that a list of commands exist on PATH. Exits on failure.
+# Usage: cms_verify_cmds numactl lscpu lspci grep bc awk
+cms_verify_cmds() {
+    local err=false
+    for cmd in "$@"; do
+        if ! command -v "${cmd}" &>/dev/null; then
+            cms_log_error "Required command not found: ${cmd}"
+            err=true
+        fi
+    done
+    if ${err}; then
+        cms_log_error "Exiting due to missing commands."
+        exit 1
+    fi
+}
+
+#################################################################################################
+# 6. System Topology Queries
+#################################################################################################
+
+# All of these populate global variables and print an INFO line.
+
+CMS_NUM_SOCKETS=0
+CMS_CORES_PER_SOCKET=0
+CMS_THREADS_PER_CORE=0
+CMS_NUMA_NODES=0
+CMS_NUM_CXL_DEVICES=0
+CMS_HYPERTHREADING=false
+
+cms_get_num_sockets() {
+    CMS_NUM_SOCKETS=$(lscpu 2>/dev/null | grep "Socket(s):" | awk -F: '{print $2}' | xargs || true)
+    CMS_NUM_SOCKETS="${CMS_NUM_SOCKETS:-1}"
+    cms_log_info "Sockets: ${CMS_NUM_SOCKETS}"
+}
+
+cms_get_cores_per_socket() {
+    CMS_CORES_PER_SOCKET=$(lscpu 2>/dev/null | grep "Core(s) per socket:" | awk -F: '{print $2}' | xargs || true)
+    CMS_CORES_PER_SOCKET="${CMS_CORES_PER_SOCKET:-1}"
+    cms_log_info "Cores per socket: ${CMS_CORES_PER_SOCKET}"
+}
+
+cms_get_threads_per_core() {
+    CMS_THREADS_PER_CORE=$(lscpu 2>/dev/null | grep "Thread(s) per core:" | awk -F: '{print $2}' | xargs || true)
+    CMS_THREADS_PER_CORE="${CMS_THREADS_PER_CORE:-1}"
+    cms_log_info "Threads per core: ${CMS_THREADS_PER_CORE}"
+}
+
+cms_get_numa_node_count() {
+    CMS_NUMA_NODES=$(lscpu 2>/dev/null | grep "NUMA node(s):" | awk -F: '{print $2}' | xargs || true)
+    if [ -z "${CMS_NUMA_NODES}" ]; then
+        # Fallback: count node directories in sysfs
+        if [ -d /sys/devices/system/node ]; then
+            CMS_NUMA_NODES=$(find /sys/devices/system/node -maxdepth 1 -name 'node[0-9]*' -type d 2>/dev/null | wc -l || true)
+        else
+            CMS_NUMA_NODES=0
+        fi
+    fi
+    # Force to integer, default 0
+    CMS_NUMA_NODES=$(( ${CMS_NUMA_NODES:-0} + 0 )) 2>/dev/null || CMS_NUMA_NODES=0
+    cms_log_info "NUMA nodes: ${CMS_NUMA_NODES}"
+}
+
+cms_get_cxl_device_count() {
+    if command -v lspci &>/dev/null; then
+        CMS_NUM_CXL_DEVICES=$(lspci 2>/dev/null | grep -ci "CXL" || true)
+        CMS_NUM_CXL_DEVICES="${CMS_NUM_CXL_DEVICES:-0}"
+    else
+        CMS_NUM_CXL_DEVICES=0
+    fi
+    cms_log_info "CXL devices (PCI): ${CMS_NUM_CXL_DEVICES}"
+}
+
+cms_check_hyperthreading() {
+    local smt_active
+    smt_active=$(cat /sys/devices/system/cpu/smt/active 2>/dev/null || echo "")
+    if [ "${smt_active}" = "1" ]; then
+        CMS_HYPERTHREADING=true
+        cms_log_info "Hyperthreading: ENABLED"
+    elif [ "${smt_active}" = "0" ]; then
+        CMS_HYPERTHREADING=false
+        cms_log_info "Hyperthreading: DISABLED"
+    else
+        # Fallback to checking threads per core
+        cms_get_threads_per_core
+        if [ "${CMS_THREADS_PER_CORE:-1}" -gt 1 ] 2>/dev/null; then
+            CMS_HYPERTHREADING=true
+            cms_log_info "Hyperthreading: ENABLED (via thread count)"
+        else
+            CMS_HYPERTHREADING=false
+            cms_log_info "Hyperthreading: DISABLED (via thread count)"
+        fi
+    fi
+}
+
+# Populate all topology variables at once
+cms_query_topology() {
+    cms_get_num_sockets
+    cms_get_cores_per_socket
+    cms_get_threads_per_core
+    cms_get_numa_node_count
+    cms_get_cxl_device_count
+    cms_check_hyperthreading
+}
+
+# Get the CPU list for a given NUMA node
+# Usage: cms_get_cpulist_for_node 0
+# Returns: sets CMS_NODE_CPULIST
+CMS_NODE_CPULIST=""
+cms_get_cpulist_for_node() {
+    local node=$1
+    CMS_NODE_CPULIST=$(cat "/sys/devices/system/node/node${node}/cpulist" 2>/dev/null || echo "")
+    if [ -z "${CMS_NODE_CPULIST}" ]; then
+        cms_log_error "Could not get CPU list for NUMA node ${node}"
+        return 1
+    fi
+    cms_log_debug "NUMA node ${node} CPUs: ${CMS_NODE_CPULIST}"
+}
+
+# Get first CPU on a given NUMA node
+# Usage: cms_get_first_cpu_on_node 0
+# Returns: sets CMS_FIRST_CPU
+CMS_FIRST_CPU=""
+cms_get_first_cpu_on_node() {
+    local node=$1
+    CMS_FIRST_CPU=$(numactl --hardware 2>/dev/null | grep "node ${node} cpus:" | cut -f2 -d":" | awk '{print $1}' || true)
+    if [ -z "${CMS_FIRST_CPU}" ]; then
+        cms_log_error "Could not determine first CPU on NUMA node ${node}"
+        return 1
+    fi
+    cms_log_debug "First CPU on NUMA node ${node}: ${CMS_FIRST_CPU}"
+}
+
+# Get memory capacity (kB) for each NUMA node
+# Returns: sets associative array CMS_NUMA_MEMTOTALS[nodeN]=<kB>
+declare -gA CMS_NUMA_MEMTOTALS 2>/dev/null || true
+cms_get_memory_per_node() {
+    for ndir in /sys/devices/system/node/node*; do
+        [ -d "${ndir}" ] || continue
+        local nid
+        nid=$(basename "${ndir}")
+        local memkb
+        memkb=$(grep 'MemTotal:' "${ndir}/meminfo" 2>/dev/null | awk '{print $4}')
+        if [ -n "${memkb}" ]; then
+            CMS_NUMA_MEMTOTALS["${nid}"]="${memkb}"
+            cms_log_info "${nid} MemTotal: ${memkb} kB"
+        fi
+    done
+}
+
+# Verify that a user-supplied NUMA node ID is valid
+# Usage: cms_verify_numa_node 2
+cms_verify_numa_node() {
+    local node=$1
+    local label="${2:-NUMA node}"
+    if [ -z "${CMS_NUMA_NODES}" ] || [ "${CMS_NUMA_NODES}" -eq 0 ]; then
+        cms_get_numa_node_count
+    fi
+    if [ "${node}" -ge "${CMS_NUMA_NODES}" ] 2>/dev/null || [ "${node}" -lt 0 ] 2>/dev/null; then
+        cms_log_error "${label} ${node} does not exist. System has NUMA nodes 0-$(( CMS_NUMA_NODES - 1 ))."
+        return 1
+    fi
+}
+
+# Verify that a user-supplied socket ID is valid
+# Usage: cms_verify_socket 1
+cms_verify_socket() {
+    local sock=$1
+    if [ -z "${CMS_NUM_SOCKETS}" ] || [ "${CMS_NUM_SOCKETS}" -eq 0 ]; then
+        cms_get_num_sockets
+    fi
+    if [ "${sock}" -ge "${CMS_NUM_SOCKETS}" ] 2>/dev/null; then
+        cms_log_error "Socket ${sock} does not exist. System has sockets 0-$(( CMS_NUM_SOCKETS - 1 ))."
+        return 1
+    fi
+}
+
+#################################################################################################
+# 7. System Info Collection
+#################################################################################################
+
+# Call the standalone collect_sysinfo.sh script.
+# arg1: output directory (defaults to ./sysinfo under CMS_OUTPUT_PATH)
+cms_collect_sysinfo() {
+    local outdir="${1:-${CMS_OUTPUT_PATH}/sysinfo}"
+    local script="${CMS_SYSINFO_SCRIPT:-/opt/cms-utils/collect_sysinfo.sh}"
+
+    # Also look next to this library file if the default path doesn't exist
+    if [ ! -x "${script}" ]; then
+        local lib_dir
+        lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd 2>/dev/null)"
+        if [ -x "${lib_dir}/collect_sysinfo.sh" ]; then
+            script="${lib_dir}/collect_sysinfo.sh"
+        fi
+    fi
+
+    if [ -x "${script}" ]; then
+        cms_log_info "Collecting system BOM via ${script}..."
+        "${script}" "${outdir}"
+    else
+        cms_log_warn "System info collector not found at ${script}"
+        cms_log_warn "Falling back to basic collection"
+        mkdir -p "${outdir}"
+        hostname > "${outdir}/hostname.txt" 2>/dev/null
+        uname -a > "${outdir}/uname.txt" 2>/dev/null
+        lscpu    > "${outdir}/lscpu.txt" 2>/dev/null
+        free -h  > "${outdir}/free.txt" 2>/dev/null
+        numactl --hardware > "${outdir}/numactl_hw.txt" 2>/dev/null
+        lspci    > "${outdir}/lspci.txt" 2>/dev/null
+    fi
+    cms_log_info "System BOM collection complete."
+}
+
+#################################################################################################
+# 8. CPU Frequency Governor
+#################################################################################################
+
+_CMS_SAVED_GOVERNOR=""
+
+# Set all CPU cores to performance governor, saving the current setting for restore
+cms_set_performance_governor() {
+    _CMS_SAVED_GOVERNOR=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo "")
+    if [ -n "${_CMS_SAVED_GOVERNOR}" ] && [ "${_CMS_SAVED_GOVERNOR}" != "performance" ]; then
+        cms_log_info "Setting CPU governor to 'performance' (was '${_CMS_SAVED_GOVERNOR}')"
+        echo "performance" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor >/dev/null 2>&1 || \
+            cms_log_warn "Could not set CPU governor (need root?)"
+    else
+        cms_log_info "CPU governor already set to 'performance' (or not available)"
+    fi
+}
+
+# Restore the CPU governor to what it was before cms_set_performance_governor
+cms_restore_governor() {
+    if [ -n "${_CMS_SAVED_GOVERNOR}" ] && [ "${_CMS_SAVED_GOVERNOR}" != "performance" ]; then
+        cms_log_info "Restoring CPU governor to '${_CMS_SAVED_GOVERNOR}'"
+        echo "${_CMS_SAVED_GOVERNOR}" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor >/dev/null 2>&1 || true
+    fi
+}
+
+#################################################################################################
+# 9. Hugepages
+#################################################################################################
+
+_CMS_SAVED_HUGEPAGES=""
+
+# Allocate N hugepages, saving current count for restore
+# Usage: cms_set_hugepages 1024
+cms_set_hugepages() {
+    local requested=$1
+    _CMS_SAVED_HUGEPAGES=$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo "")
+    cms_log_info "Setting nr_hugepages to ${requested} (was ${_CMS_SAVED_HUGEPAGES})"
+    echo "${requested}" > /proc/sys/vm/nr_hugepages 2>/dev/null || \
+        cms_log_warn "Could not set hugepages (need root?)"
+}
+
+cms_restore_hugepages() {
+    if [ -n "${_CMS_SAVED_HUGEPAGES}" ]; then
+        cms_log_info "Restoring nr_hugepages to ${_CMS_SAVED_HUGEPAGES}"
+        echo "${_CMS_SAVED_HUGEPAGES}" > /proc/sys/vm/nr_hugepages 2>/dev/null || true
+    fi
+}
+
+#################################################################################################
+# 10. Page Cache
+#################################################################################################
+
+# Clear the page cache. Requires root.
+cms_clear_page_cache() {
+    cms_log_info "Clearing page cache..."
+    sync && echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || \
+        cms_log_warn "Could not clear page cache (need root?)"
+}
+
+#################################################################################################
+# 11. Unit Conversion
+#################################################################################################
+
+# Convert a human-readable size string (e.g. "16G", "512M", "1024K") to bytes.
+# Usage: cms_to_bytes "16G"
+cms_to_bytes() {
+    local input
+    input=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+    local last_char="${input: -1}"
+    local numeric="${input:0:$(( ${#input} - 1 ))}"
+
+    if [[ "${numeric}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+        case "${last_char}" in
+            K) echo "$(echo "scale=0; ${numeric} * 1024" | bc)";;
+            M) echo "$(echo "scale=0; ${numeric} * 1024 * 1024" | bc)";;
+            G) echo "$(echo "scale=0; ${numeric} * 1024 * 1024 * 1024" | bc)";;
+            T) echo "$(echo "scale=0; ${numeric} * 1024 * 1024 * 1024 * 1024" | bc)";;
+            *) # No suffix, treat as bytes
+               echo "${input}";;
+        esac
+    elif [[ "${input}" =~ ^[0-9]+$ ]]; then
+        echo "${input}"
+    else
+        cms_log_error "Invalid size string: $1"
+        return 1
+    fi
+}
+
+#################################################################################################
+# 12. Results Packaging
+#################################################################################################
+
+# Create a tarball of the output directory.
+# Usage: cms_package_results [output_path]
+cms_package_results() {
+    local path="${1:-${CMS_OUTPUT_PATH}}"
+    # Resolve relative paths like "." to an absolute path for naming
+    local resolved_path
+    resolved_path=$(cd "${path}" 2>/dev/null && pwd) || resolved_path="${path}"
+    local tarball="${resolved_path}.tar.gz"
+    cms_log_info "Packaging results to ${tarball}..."
+    tar czf "${tarball}" -C "$(dirname "${resolved_path}")" "$(basename "${resolved_path}")" 2>/dev/null || \
+        cms_log_warn "Could not create results tarball"
+    cms_log_info "Results archive: ${tarball}"
+}
+
+cms_log_debug "cms_common.sh v${CMS_COMMON_VERSION} loaded"

--- a/src/container-runtime/utils/collect_sysinfo.sh
+++ b/src/container-runtime/utils/collect_sysinfo.sh
@@ -1,0 +1,646 @@
+#!/usr/bin/env bash
+
+#################################################################################################
+# OCP SRV CMS - System Information Collector (collect_sysinfo.sh)
+#
+# Collects a comprehensive hardware and software bill-of-materials (BOM) from inside
+# a container. Designed to run in a privileged Docker container to maximize visibility
+# into the host system. Output is organized into subdirectories by category.
+#
+# This script lives in the utils/ directory and is COPY'd into every benchmark container.
+# Individual benchmarks call it before their run to capture the full system state.
+#
+# Usage: ./collect_sysinfo.sh [output_directory]
+#   output_directory: defaults to ./sysinfo
+#
+# The script is designed to be graceful - missing tools or inaccessible paths produce
+# a "not available" note rather than errors. It never exits non-zero.
+#################################################################################################
+
+SYSINFO_VERSION="0.1.0"
+SYSINFO_DIR="${1:-./sysinfo}"
+
+mkdir -p "${SYSINFO_DIR}"/{bios_firmware,cpu,memory,numa_cxl,pci_devices,network,storage,kernel_os,packages,runtime,gpu,power}
+
+#################################################################################################
+# Collection helpers
+#################################################################################################
+
+_sysinfo_log() {
+    echo "[SYSINFO] $(date '+%Y-%m-%d %H:%M:%S') - $*"
+}
+
+# Run a command, save stdout+stderr to a file. Skip silently if command missing or fails.
+# arg1: output path relative to SYSINFO_DIR
+# arg2+: command and arguments
+_collect_cmd() {
+    local outfile="${SYSINFO_DIR}/$1"; shift
+    if command -v "$1" &>/dev/null; then
+        "$@" > "${outfile}" 2>&1 || true
+    else
+        echo "# Command not found: $1" > "${outfile}"
+    fi
+}
+
+# Copy or cat a file from the host/proc/sys filesystems.
+# arg1: output path relative to SYSINFO_DIR
+# arg2: source file
+_collect_file() {
+    local outfile="${SYSINFO_DIR}/$1"
+    local src="$2"
+    if [ -r "${src}" ]; then
+        if [ -s "${src}" ]; then
+            cat "${src}" > "${outfile}" 2>/dev/null || echo "# Unreadable: ${src}" > "${outfile}"
+        else
+            echo "# Empty: ${src}" > "${outfile}"
+        fi
+    else
+        echo "# Not available: ${src}" > "${outfile}"
+    fi
+}
+
+# Walk a directory tree of readable files and dump key=value style output.
+# arg1: output path relative to SYSINFO_DIR
+# arg2: source directory
+_collect_tree() {
+    local outfile="${SYSINFO_DIR}/$1"
+    local srcdir="$2"
+    if [ -d "${srcdir}" ]; then
+        find "${srcdir}" -type f -readable 2>/dev/null | sort | while read -r f; do
+            echo "=== ${f} ==="
+            cat "${f}" 2>/dev/null || echo "# unreadable"
+            echo ""
+        done > "${outfile}"
+    else
+        echo "# Directory not available: ${srcdir}" > "${outfile}"
+    fi
+}
+
+#################################################################################################
+# Begin collection
+#################################################################################################
+
+_sysinfo_log "Starting system information collection v${SYSINFO_VERSION}"
+_sysinfo_log "Output directory: ${SYSINFO_DIR}"
+
+# ----- Collection metadata -----
+{
+    echo "collection_timestamp_utc=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "collection_timestamp_local=$(date '+%Y-%m-%d %H:%M:%S %Z')"
+    echo "sysinfo_collector_version=${SYSINFO_VERSION}"
+    echo "hostname=$(hostname 2>/dev/null)"
+    echo "container_id=$(cat /proc/self/cgroup 2>/dev/null | grep -oE '[a-f0-9]{64}' | head -1)"
+} > "${SYSINFO_DIR}/collection_metadata.txt"
+
+#################################################################################################
+# 1. BIOS / Firmware / Baseboard
+#################################################################################################
+_sysinfo_log "Collecting BIOS / firmware / baseboard..."
+
+_collect_cmd  bios_firmware/dmidecode_full.txt         dmidecode
+_collect_cmd  bios_firmware/dmidecode_bios.txt          dmidecode -t bios
+_collect_cmd  bios_firmware/dmidecode_system.txt        dmidecode -t system
+_collect_cmd  bios_firmware/dmidecode_baseboard.txt     dmidecode -t baseboard
+_collect_cmd  bios_firmware/dmidecode_chassis.txt       dmidecode -t chassis
+_collect_cmd  bios_firmware/dmidecode_processor.txt     dmidecode -t processor
+_collect_cmd  bios_firmware/dmidecode_memory.txt        dmidecode -t memory
+_collect_cmd  bios_firmware/dmidecode_cache.txt         dmidecode -t cache
+_collect_cmd  bios_firmware/dmidecode_connector.txt     dmidecode -t connector
+_collect_cmd  bios_firmware/dmidecode_slot.txt          dmidecode -t slot
+
+_collect_file bios_firmware/dmi_product_name.txt        /sys/class/dmi/id/product_name
+_collect_file bios_firmware/dmi_product_serial.txt      /sys/class/dmi/id/product_serial
+_collect_file bios_firmware/dmi_product_uuid.txt        /sys/class/dmi/id/product_uuid
+_collect_file bios_firmware/dmi_board_vendor.txt        /sys/class/dmi/id/board_vendor
+_collect_file bios_firmware/dmi_board_name.txt          /sys/class/dmi/id/board_name
+_collect_file bios_firmware/dmi_board_version.txt       /sys/class/dmi/id/board_version
+_collect_file bios_firmware/dmi_bios_vendor.txt         /sys/class/dmi/id/bios_vendor
+_collect_file bios_firmware/dmi_bios_version.txt        /sys/class/dmi/id/bios_version
+_collect_file bios_firmware/dmi_bios_date.txt           /sys/class/dmi/id/bios_date
+_collect_file bios_firmware/dmi_chassis_vendor.txt      /sys/class/dmi/id/chassis_vendor
+_collect_file bios_firmware/dmi_chassis_type.txt        /sys/class/dmi/id/chassis_type
+_collect_file bios_firmware/dmi_sys_vendor.txt          /sys/class/dmi/id/sys_vendor
+
+#################################################################################################
+# 2. CPU
+#################################################################################################
+_sysinfo_log "Collecting CPU information..."
+
+_collect_cmd  cpu/lscpu.txt                             lscpu
+_collect_cmd  cpu/lscpu_extended.txt                    lscpu -e
+_collect_cmd  cpu/lscpu_parse.txt                       lscpu -p
+_collect_cmd  cpu/lscpu_json.txt                        lscpu -J
+_collect_file cpu/cpuinfo.txt                           /proc/cpuinfo
+_collect_file cpu/cpu_scaling_governor.txt              /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+_collect_file cpu/cpu_scaling_driver.txt                /sys/devices/system/cpu/cpu0/cpufreq/scaling_driver
+_collect_file cpu/cpu_energy_perf_policy.txt            /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference
+_collect_file cpu/cpuinfo_max_freq.txt                  /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq
+_collect_file cpu/cpuinfo_min_freq.txt                  /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq
+_collect_file cpu/scaling_cur_freq.txt                  /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq
+_collect_file cpu/smt_active.txt                        /sys/devices/system/cpu/smt/active
+_collect_file cpu/smt_control.txt                       /sys/devices/system/cpu/smt/control
+_collect_file cpu/microcode_version.txt                 /sys/devices/system/cpu/cpu0/microcode/version
+
+# Per-CPU current frequency snapshot
+if [ -d /sys/devices/system/cpu/cpu0/cpufreq ]; then
+    {
+        for cpudir in /sys/devices/system/cpu/cpu[0-9]*; do
+            id=$(basename "${cpudir}")
+            freq="${cpudir}/cpufreq/scaling_cur_freq"
+            [ -r "${freq}" ] && echo "${id}: $(cat "${freq}") kHz"
+        done
+    } > "${SYSINFO_DIR}/cpu/all_cpu_frequencies.txt" 2>/dev/null
+else
+    echo "# cpufreq not available" > "${SYSINFO_DIR}/cpu/all_cpu_frequencies.txt"
+fi
+
+# Per-CPU scaling governor snapshot
+if [ -d /sys/devices/system/cpu/cpu0/cpufreq ]; then
+    {
+        for cpudir in /sys/devices/system/cpu/cpu[0-9]*; do
+            id=$(basename "${cpudir}")
+            gov="${cpudir}/cpufreq/scaling_governor"
+            [ -r "${gov}" ] && echo "${id}: $(cat "${gov}")"
+        done
+    } > "${SYSINFO_DIR}/cpu/all_cpu_governors.txt" 2>/dev/null
+else
+    echo "# cpufreq not available" > "${SYSINFO_DIR}/cpu/all_cpu_governors.txt"
+fi
+
+# CPU vulnerabilities
+_collect_tree cpu/vulnerabilities.txt                   /sys/devices/system/cpu/vulnerabilities
+
+# CPU cache topology
+if [ -d /sys/devices/system/cpu/cpu0/cache ]; then
+    {
+        for idx in /sys/devices/system/cpu/cpu0/cache/index*; do
+            [ -d "${idx}" ] || continue
+            level=$(cat "${idx}/level" 2>/dev/null)
+            type=$(cat "${idx}/type" 2>/dev/null)
+            size=$(cat "${idx}/size" 2>/dev/null)
+            ways=$(cat "${idx}/ways_of_associativity" 2>/dev/null)
+            shared=$(cat "${idx}/shared_cpu_list" 2>/dev/null)
+            echo "$(basename ${idx}): L${level} ${type} ${size} ${ways}-way shared_by=[${shared}]"
+        done
+    } > "${SYSINFO_DIR}/cpu/cache_topology.txt" 2>/dev/null
+fi
+
+#################################################################################################
+# 3. Memory (DRAM)
+#################################################################################################
+_sysinfo_log "Collecting memory information..."
+
+_collect_file memory/meminfo.txt                        /proc/meminfo
+_collect_cmd  memory/free.txt                           free -h
+_collect_cmd  memory/free_bytes.txt                     free -b
+_collect_file memory/buddyinfo.txt                      /proc/buddyinfo
+_collect_file memory/pagetypeinfo.txt                   /proc/pagetypeinfo
+_collect_file memory/slabinfo.txt                       /proc/slabinfo
+_collect_file memory/vmstat.txt                         /proc/vmstat
+_collect_file memory/zoneinfo.txt                       /proc/zoneinfo
+
+# Hugepages
+_collect_file memory/nr_hugepages.txt                   /proc/sys/vm/nr_hugepages
+_collect_file memory/nr_hugepages_mempolicy.txt         /proc/sys/vm/nr_hugepages_mempolicy
+_collect_file memory/nr_overcommit_hugepages.txt        /proc/sys/vm/nr_overcommit_hugepages
+_collect_file memory/thp_enabled.txt                    /sys/kernel/mm/transparent_hugepage/enabled
+_collect_file memory/thp_defrag.txt                     /sys/kernel/mm/transparent_hugepage/defrag
+_collect_file memory/thp_shmem_enabled.txt              /sys/kernel/mm/transparent_hugepage/shmem_enabled
+
+# VM tunables
+_collect_file memory/swappiness.txt                     /proc/sys/vm/swappiness
+_collect_file memory/overcommit_memory.txt              /proc/sys/vm/overcommit_memory
+_collect_file memory/overcommit_ratio.txt               /proc/sys/vm/overcommit_ratio
+_collect_file memory/min_free_kbytes.txt                /proc/sys/vm/min_free_kbytes
+_collect_file memory/zone_reclaim_mode.txt              /proc/sys/vm/zone_reclaim_mode
+_collect_file memory/dirty_ratio.txt                    /proc/sys/vm/dirty_ratio
+_collect_file memory/dirty_background_ratio.txt         /proc/sys/vm/dirty_background_ratio
+_collect_file memory/watermark_boost_factor.txt         /proc/sys/vm/watermark_boost_factor
+_collect_file memory/watermark_scale_factor.txt         /proc/sys/vm/watermark_scale_factor
+_collect_file memory/vfs_cache_pressure.txt             /proc/sys/vm/vfs_cache_pressure
+_collect_file memory/compact_memory.txt                 /proc/sys/vm/compact_memory
+_collect_file memory/oom_kill_allocating_task.txt        /proc/sys/vm/oom_kill_allocating_task
+
+#################################################################################################
+# 4. NUMA Topology & CXL Devices
+#################################################################################################
+_sysinfo_log "Collecting NUMA topology and CXL device information..."
+
+_collect_cmd  numa_cxl/numactl_hardware.txt             numactl --hardware
+_collect_cmd  numa_cxl/numactl_show.txt                 numactl --show
+_collect_cmd  numa_cxl/numastat.txt                     numastat
+_collect_cmd  numa_cxl/numastat_m.txt                   numastat -m
+_collect_file numa_cxl/numa_balancing.txt               /proc/sys/kernel/numa_balancing
+_collect_file numa_cxl/numa_demotion_enabled.txt        /sys/kernel/mm/numa/demotion_enabled
+
+# Per-NUMA-node detail
+for node_dir in /sys/devices/system/node/node[0-9]*; do
+    [ -d "${node_dir}" ] || continue
+    nid=$(basename "${node_dir}")
+    out="${SYSINFO_DIR}/numa_cxl/${nid}"
+    mkdir -p "${out}"
+    cat "${node_dir}/meminfo"   > "${out}/meminfo.txt"   2>/dev/null || true
+    cat "${node_dir}/cpulist"   > "${out}/cpulist.txt"   2>/dev/null || true
+    cat "${node_dir}/distance"  > "${out}/distance.txt"  2>/dev/null || true
+    cat "${node_dir}/numastat"  > "${out}/numastat.txt"  2>/dev/null || true
+    cat "${node_dir}/vmstat"    > "${out}/vmstat.txt"     2>/dev/null || true
+done
+
+# NUMA distance matrix (human-readable)
+{
+    echo "NUMA Distance Matrix"
+    echo "===================="
+    numactl --hardware 2>/dev/null | grep -A 100 "node distances"
+} > "${SYSINFO_DIR}/numa_cxl/numa_distance_matrix.txt" 2>/dev/null
+
+# Memory topology table (mirrors src/tools/showmemtopo)
+{
+    dmidecode -t memory 2>/dev/null | awk '
+    BEGIN {
+        printf "%8s | %14s | %14s | %12s | %8s | %20s | %s\n",
+               "Handle","Manufacturer","Part Number","Speed","Capacity","Bank Locator","Locator";
+        printf "=========|================|================|==============|==========|======================|====================\n";
+        FoundDIMM=0;
+    }
+    $1=="Handle"     { Handle=substr($2,1,length($2)-1); ReadNextLine=1; next }
+    ReadNextLine     { FoundDIMM=($0~/Memory Device/); ReadNextLine=0; next }
+    $1=="Size:"      { Size=($2!="No")? $2$3 : "empty"; next }
+    FoundDIMM && $1=="Locator:"       { Locator=""; for(i=2;i<=NF;i++) Locator=Locator" "$i; next }
+    FoundDIMM && $1=="Bank" && $2=="Locator:" { BankLoc=""; for(i=3;i<=NF;i++) BankLoc=BankLoc" "$i; next }
+    FoundDIMM && $1=="Speed:"         { Speed=""; for(i=2;i<=NF;i++) Speed=Speed" "$i; next }
+    FoundDIMM && $1=="Manufacturer:"  { Mfr=""; for(i=2;i<=NF;i++) Mfr=Mfr" "$i; next }
+    FoundDIMM && $1=="Part" && $2=="Number:" { PN=""; for(i=3;i<=NF;i++) PN=PN" "$i; next }
+    FoundDIMM && Size && Speed {
+        printf "%8s | %14s | %14s | %12s | %8s | %20s | %s\n",
+               Handle, Mfr, PN, Speed, Size, BankLoc, Locator;
+        Size=""; Mfr=""; PN=""; Speed=""; BankLoc="";
+    }'
+} > "${SYSINFO_DIR}/numa_cxl/memory_topology.txt" 2>/dev/null
+
+# CXL devices
+_collect_cmd  numa_cxl/cxl_list.txt                     cxl list
+_collect_cmd  numa_cxl/cxl_list_memdevs.txt             cxl list -M
+_collect_cmd  numa_cxl/cxl_list_verbose.txt             cxl list -v
+_collect_cmd  numa_cxl/cxl_list_all.txt                 cxl list -BMDPRTi
+
+# CXL sysfs tree (full dump)
+_collect_tree numa_cxl/cxl_sysfs.txt                    /sys/bus/cxl
+
+#################################################################################################
+# 5. PCI Devices
+#################################################################################################
+_sysinfo_log "Collecting PCI device information..."
+
+_collect_cmd  pci_devices/lspci.txt                     lspci
+_collect_cmd  pci_devices/lspci_verbose.txt             lspci -vvv
+_collect_cmd  pci_devices/lspci_tree.txt                lspci -tv
+_collect_cmd  pci_devices/lspci_numeric.txt             lspci -nn
+_collect_cmd  pci_devices/lspci_kernel.txt              lspci -k
+
+#################################################################################################
+# 6. Network Interfaces
+#################################################################################################
+_sysinfo_log "Collecting network information..."
+
+_collect_cmd  network/ip_addr.txt                       ip addr show
+_collect_cmd  network/ip_link.txt                       ip link show
+_collect_cmd  network/ip_route.txt                      ip route show
+_collect_cmd  network/ifconfig.txt                      ifconfig -a
+_collect_cmd  network/ss_summary.txt                    ss -s
+_collect_cmd  network/ss_listening.txt                  ss -tlnp
+_collect_file network/hostname.txt                      /etc/hostname
+
+# Per-NIC ethtool info (physical NICs only)
+if command -v ethtool &>/dev/null; then
+    for iface in $(ls /sys/class/net/ 2>/dev/null); do
+        [ "${iface}" = "lo" ] && continue
+        {
+            echo "=== ${iface} ==="
+            ethtool "${iface}" 2>/dev/null
+            echo ""
+            echo "--- driver ---"
+            ethtool -i "${iface}" 2>/dev/null
+            echo ""
+        }
+    done > "${SYSINFO_DIR}/network/ethtool_all.txt" 2>/dev/null
+fi
+
+#################################################################################################
+# 7. Storage
+#################################################################################################
+_sysinfo_log "Collecting storage information..."
+
+_collect_cmd  storage/lsblk.txt                         lsblk -o NAME,SIZE,TYPE,MOUNTPOINTS,MODEL,VENDOR,SERIAL,ROTA
+_collect_cmd  storage/lsblk_all.txt                     lsblk -a
+_collect_cmd  storage/lsblk_json.txt                    lsblk -J
+_collect_cmd  storage/df.txt                            df -hT
+_collect_cmd  storage/mount.txt                         mount
+_collect_cmd  storage/findmnt.txt                       findmnt
+_collect_file storage/partitions.txt                    /proc/partitions
+_collect_file storage/diskstats.txt                     /proc/diskstats
+_collect_file storage/mounts.txt                        /proc/mounts
+_collect_file storage/mdstat.txt                        /proc/mdstat
+_collect_cmd  storage/vgdisplay.txt                     vgdisplay
+_collect_cmd  storage/pvdisplay.txt                     pvdisplay
+_collect_cmd  storage/lvdisplay.txt                     lvdisplay
+
+#################################################################################################
+# 8. Kernel / OS / Boot
+#################################################################################################
+_sysinfo_log "Collecting kernel and OS information..."
+
+_collect_cmd  kernel_os/uname.txt                       uname -a
+_collect_file kernel_os/os_release.txt                  /etc/os-release
+_collect_file kernel_os/lsb_release.txt                 /etc/lsb-release
+_collect_cmd  kernel_os/lsb_release_a.txt               lsb_release -a
+_collect_file kernel_os/version.txt                     /proc/version
+_collect_file kernel_os/cmdline.txt                     /proc/cmdline
+_collect_file kernel_os/modules.txt                     /proc/modules
+_collect_cmd  kernel_os/lsmod.txt                       lsmod
+_collect_file kernel_os/uptime.txt                      /proc/uptime
+_collect_cmd  kernel_os/uptime_human.txt                uptime
+_collect_file kernel_os/loadavg.txt                     /proc/loadavg
+_collect_file kernel_os/stat.txt                        /proc/stat
+_collect_file kernel_os/interrupts.txt                  /proc/interrupts
+_collect_file kernel_os/softirqs.txt                    /proc/softirqs
+_collect_file kernel_os/schedstat.txt                   /proc/schedstat
+
+# Kernel config
+if [ -f /proc/config.gz ]; then
+    zcat /proc/config.gz > "${SYSINFO_DIR}/kernel_os/kernel_config.txt" 2>/dev/null || true
+elif ls /boot/config-"$(uname -r)" 1>/dev/null 2>&1; then
+    cp "/boot/config-$(uname -r)" "${SYSINFO_DIR}/kernel_os/kernel_config.txt" 2>/dev/null || true
+else
+    echo "# Kernel config not available" > "${SYSINFO_DIR}/kernel_os/kernel_config.txt"
+fi
+
+# Full sysctl dump
+_collect_cmd  kernel_os/sysctl_all.txt                  sysctl -a
+
+# Curated tunables that matter for memory/CXL benchmarking
+{
+    echo "=== Key Kernel Tunables for CMS Benchmarking ==="
+    echo ""
+    for param in \
+        kernel.sched_migration_cost_ns \
+        kernel.sched_min_granularity_ns \
+        kernel.sched_wakeup_granularity_ns \
+        kernel.numa_balancing \
+        kernel.numa_balancing_scan_delay_ms \
+        kernel.numa_balancing_scan_period_min_ms \
+        kernel.numa_balancing_scan_period_max_ms \
+        kernel.numa_balancing_scan_size_mb \
+        vm.swappiness \
+        vm.overcommit_memory \
+        vm.overcommit_ratio \
+        vm.min_free_kbytes \
+        vm.zone_reclaim_mode \
+        vm.dirty_ratio \
+        vm.dirty_background_ratio \
+        vm.nr_hugepages \
+        vm.nr_overcommit_hugepages \
+        vm.vfs_cache_pressure \
+        vm.watermark_boost_factor \
+        vm.watermark_scale_factor \
+        net.core.somaxconn \
+        net.core.netdev_max_backlog \
+        net.ipv4.tcp_max_syn_backlog \
+        net.ipv4.tcp_fin_timeout \
+        net.ipv4.tcp_tw_reuse \
+        net.ipv4.tcp_keepalive_time \
+        ; do
+        val=$(sysctl -n "${param}" 2>/dev/null || echo "N/A")
+        printf "%-55s = %s\n" "${param}" "${val}"
+    done
+} > "${SYSINFO_DIR}/kernel_os/key_tunables.txt" 2>/dev/null
+
+# Security modules
+_collect_file kernel_os/selinux_enforce.txt              /sys/fs/selinux/enforce
+_collect_cmd  kernel_os/getenforce.txt                   getenforce
+_collect_file kernel_os/apparmor_profiles.txt            /sys/kernel/security/apparmor/profiles
+
+#################################################################################################
+# 9. Installed Packages / Software BOM
+#################################################################################################
+_sysinfo_log "Collecting installed packages and software BOM..."
+
+# Debian/Ubuntu
+if command -v dpkg &>/dev/null; then
+    dpkg -l                  > "${SYSINFO_DIR}/packages/dpkg_list.txt"       2>/dev/null
+    dpkg --get-selections    > "${SYSINFO_DIR}/packages/dpkg_selections.txt" 2>/dev/null
+    apt list --installed     > "${SYSINFO_DIR}/packages/apt_installed.txt"   2>/dev/null
+fi
+
+# RHEL/Fedora/CentOS
+if command -v rpm &>/dev/null; then
+    rpm -qa --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort \
+        > "${SYSINFO_DIR}/packages/rpm_list.txt" 2>/dev/null
+fi
+if command -v dnf &>/dev/null; then
+    dnf list installed > "${SYSINFO_DIR}/packages/dnf_installed.txt" 2>/dev/null
+elif command -v yum &>/dev/null; then
+    yum list installed > "${SYSINFO_DIR}/packages/yum_installed.txt" 2>/dev/null
+fi
+
+# Python
+if command -v pip3 &>/dev/null; then
+    pip3 list --format=freeze > "${SYSINFO_DIR}/packages/pip3_list.txt" 2>/dev/null
+elif command -v pip &>/dev/null; then
+    pip list --format=freeze  > "${SYSINFO_DIR}/packages/pip_list.txt"  2>/dev/null
+fi
+
+# Shared libraries
+_collect_cmd  packages/ldconfig.txt                     ldconfig -p
+
+# C library
+_collect_cmd  packages/libc_version.txt                 ldd --version
+
+# Key tool versions
+{
+    echo "=== Key Tool Versions ==="
+    echo ""
+    for cmd in gcc g++ make cmake python3 python pip3 numactl memcached memaslap redis-server; do
+        if command -v "${cmd}" &>/dev/null; then
+            ver=$("${cmd}" --version 2>&1 | head -1)
+            printf "%-25s : %s\n" "${cmd}" "${ver}"
+        else
+            printf "%-25s : NOT INSTALLED\n" "${cmd}"
+        fi
+    done
+    # Special-case tools that use non-standard version flags
+    if command -v lscpu &>/dev/null; then
+        printf "%-25s : %s\n" "util-linux (lscpu)" "$(lscpu -V 2>&1 | head -1)"
+    fi
+    if command -v cxl &>/dev/null; then
+        printf "%-25s : %s\n" "cxl-cli" "$(cxl --version 2>&1 | head -1)"
+    fi
+    if command -v mlc &>/dev/null; then
+        printf "%-25s : %s\n" "mlc" "$(mlc --version 2>&1 | head -1)"
+    fi
+} > "${SYSINFO_DIR}/packages/tool_versions.txt" 2>/dev/null
+
+#################################################################################################
+# 10. Container Runtime Environment
+#################################################################################################
+_sysinfo_log "Collecting container runtime environment..."
+
+# Environment variables (strip anything that looks like a secret)
+env | grep -viE 'password|secret|token|key|credential|auth' | sort \
+    > "${SYSINFO_DIR}/runtime/environment.txt" 2>/dev/null
+
+# Cgroup v2
+_collect_file runtime/cgroup.txt                        /proc/self/cgroup
+_collect_file runtime/cgroup_controllers.txt            /sys/fs/cgroup/cgroup.controllers
+_collect_file runtime/cgroup_memory_max.txt             /sys/fs/cgroup/memory.max
+_collect_file runtime/cgroup_memory_current.txt         /sys/fs/cgroup/memory.current
+_collect_file runtime/cgroup_memory_swap_max.txt        /sys/fs/cgroup/memory.swap.max
+_collect_file runtime/cgroup_cpu_max.txt                /sys/fs/cgroup/cpu.max
+_collect_file runtime/cgroup_cpuset_cpus.txt            /sys/fs/cgroup/cpuset.cpus.effective
+_collect_file runtime/cgroup_cpuset_mems.txt            /sys/fs/cgroup/cpuset.mems.effective
+
+# Cgroup v1 (older kernels / runtimes)
+if [ -d /sys/fs/cgroup/memory ]; then
+    _collect_file runtime/cgv1_memory_limit.txt         /sys/fs/cgroup/memory/memory.limit_in_bytes
+    _collect_file runtime/cgv1_memory_usage.txt         /sys/fs/cgroup/memory/memory.usage_in_bytes
+    _collect_file runtime/cgv1_memsw_limit.txt          /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes
+fi
+if [ -d /sys/fs/cgroup/cpuset ]; then
+    _collect_file runtime/cgv1_cpuset_cpus.txt          /sys/fs/cgroup/cpuset/cpuset.cpus
+    _collect_file runtime/cgv1_cpuset_mems.txt          /sys/fs/cgroup/cpuset/cpuset.mems
+fi
+
+# Process limits
+_collect_file runtime/proc_limits.txt                   /proc/self/limits
+_collect_file runtime/proc_status.txt                   /proc/self/status
+_collect_cmd  runtime/ulimit.txt                        bash -c "ulimit -a"
+
+#################################################################################################
+# 11. GPU (if present)
+#################################################################################################
+_sysinfo_log "Collecting GPU information (if present)..."
+
+_collect_cmd  gpu/nvidia_smi.txt                        nvidia-smi
+_collect_cmd  gpu/nvidia_smi_query.txt                  nvidia-smi -q
+_collect_cmd  gpu/rocm_smi.txt                          rocm-smi
+_collect_cmd  gpu/rocm_smi_all.txt                      rocm-smi --showall
+
+#################################################################################################
+# 12. Power / Thermal / Sensors
+#################################################################################################
+_sysinfo_log "Collecting power and thermal information..."
+
+_collect_cmd  power/sensors.txt                         sensors
+_collect_cmd  power/ipmitool_sdr.txt                    ipmitool sdr
+_collect_cmd  power/ipmitool_fru.txt                    ipmitool fru
+
+# Thermal zones
+if [ -d /sys/class/thermal ]; then
+    {
+        for tz in /sys/class/thermal/thermal_zone*; do
+            [ -d "${tz}" ] || continue
+            name=$(basename "${tz}")
+            type=$(cat "${tz}/type" 2>/dev/null || echo "unknown")
+            temp=$(cat "${tz}/temp" 2>/dev/null || echo "N/A")
+            echo "${name}: type=${type}  temp=${temp}"
+        done
+    } > "${SYSINFO_DIR}/power/thermal_zones.txt" 2>/dev/null
+fi
+
+# Intel RAPL energy counters
+if [ -d /sys/class/powercap ]; then
+    {
+        find /sys/class/powercap -type f \( -name "name" -o -name "energy_uj" -o -name "max_energy_range_uj" \) \
+            2>/dev/null | sort | while read -r f; do
+            echo "=== ${f} ==="
+            cat "${f}" 2>/dev/null
+            echo ""
+        done
+    } > "${SYSINFO_DIR}/power/rapl_energy.txt" 2>/dev/null
+fi
+
+#################################################################################################
+# SUMMARY
+#################################################################################################
+_sysinfo_log "Generating summary..."
+
+{
+    echo "============================================================"
+    echo " OCP SRV CMS - System Information Summary"
+    echo " Collected: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo " Collector Version: ${SYSINFO_VERSION}"
+    echo "============================================================"
+    echo ""
+
+    echo "--- Platform ---"
+    printf "  Vendor:   %s\n" "$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || echo 'N/A')"
+    printf "  Product:  %s\n" "$(cat /sys/class/dmi/id/product_name 2>/dev/null || echo 'N/A')"
+    printf "  Board:    %s %s\n" "$(cat /sys/class/dmi/id/board_vendor 2>/dev/null || echo 'N/A')" \
+                                  "$(cat /sys/class/dmi/id/board_name 2>/dev/null || echo '')"
+    printf "  Chassis:  %s\n" "$(cat /sys/class/dmi/id/chassis_vendor 2>/dev/null || echo 'N/A')"
+    echo ""
+
+    echo "--- BIOS / Firmware ---"
+    printf "  Vendor:   %s\n" "$(cat /sys/class/dmi/id/bios_vendor 2>/dev/null || echo 'N/A')"
+    printf "  Version:  %s\n" "$(cat /sys/class/dmi/id/bios_version 2>/dev/null || echo 'N/A')"
+    printf "  Date:     %s\n" "$(cat /sys/class/dmi/id/bios_date 2>/dev/null || echo 'N/A')"
+    echo ""
+
+    echo "--- CPU ---"
+    lscpu 2>/dev/null | grep -E "^Model name|^Socket|^Core|^Thread|^CPU\(s\)|^NUMA|^CPU.*MHz|^Vendor|^Architecture|^Byte Order" | sed 's/^/  /'
+    echo ""
+
+    echo "--- Memory ---"
+    free -h 2>/dev/null | sed 's/^/  /'
+    echo ""
+
+    echo "--- NUMA Topology ---"
+    numactl --hardware 2>/dev/null | sed 's/^/  /'
+    echo ""
+
+    echo "--- CXL Devices ---"
+    if command -v cxl &>/dev/null; then
+        cxl_out=$(cxl list 2>/dev/null)
+        if [ -n "${cxl_out}" ] && [ "${cxl_out}" != "[]" ]; then
+            echo "${cxl_out}" | sed 's/^/  /'
+        else
+            echo "  No CXL devices found"
+        fi
+    else
+        echo "  cxl-cli not available"
+    fi
+    echo ""
+
+    echo "--- Kernel ---"
+    printf "  %s\n" "$(uname -a 2>/dev/null)"
+    echo ""
+
+    echo "--- OS ---"
+    grep -E "^NAME=|^VERSION=|^ID=" /etc/os-release 2>/dev/null | sed 's/^/  /'
+    echo ""
+
+    echo "--- Container ---"
+    printf "  Hostname:  %s\n" "$(hostname 2>/dev/null)"
+    printf "  PID 1:     %s\n" "$(cat /proc/1/cmdline 2>/dev/null | tr '\0' ' ')"
+    echo ""
+
+    echo "--- PCI (CXL / Memory-related) ---"
+    lspci 2>/dev/null | grep -iE "CXL|memory controller|host bridge|system peripheral" | sed 's/^/  /' || echo "  None found"
+    echo ""
+
+    echo "--- DIMM Summary ---"
+    dmidecode -t memory 2>/dev/null | grep -cE "Size:.*[0-9]+ [MG]B" | xargs -I{} echo "  Populated DIMMs: {}"
+    dmidecode -t memory 2>/dev/null | grep -E "Size:.*[0-9]+ [MG]B" | awk '{sum+=$2} END{printf "  Total Capacity:  %d GB\n", sum/1024}' 2>/dev/null
+    echo ""
+
+} > "${SYSINFO_DIR}/SUMMARY.txt" 2>/dev/null
+
+#################################################################################################
+# Archive
+#################################################################################################
+_sysinfo_log "Creating archive..."
+tar czf "${SYSINFO_DIR}.tar.gz" -C "$(dirname "${SYSINFO_DIR}")" "$(basename "${SYSINFO_DIR}")" 2>/dev/null || true
+
+_sysinfo_log "System information collection complete."
+_sysinfo_log "  Summary:  ${SYSINFO_DIR}/SUMMARY.txt"
+_sysinfo_log "  Full:     ${SYSINFO_DIR}/"
+_sysinfo_log "  Archive:  ${SYSINFO_DIR}.tar.gz"

--- a/src/container-runtime/utils/generate_report.sh
+++ b/src/container-runtime/utils/generate_report.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+
+#################################################################################################
+# OCP SRV CMS - Report Generator (generate_report.sh)
+#
+# Generates summary output files from benchmark results. Called after a benchmark completes
+# to produce the deliverables described in the container-runtime README:
+#   - CSV summary
+#   - HTML report
+#   - Tarball of all raw output
+#
+# Usage: ./generate_report.sh <results_dir> <benchmark_name> [csv_file]
+#
+# This script expects:
+#   - A sysinfo/ directory (from collect_sysinfo.sh)
+#   - Raw benchmark output files in the results directory
+#   - An optional CSV results file to embed in the HTML report
+#
+# The script is intentionally simple. Individual benchmarks may extend it or call
+# it as a base and then append benchmark-specific report sections.
+#################################################################################################
+
+REPORT_VERSION="0.1.0"
+
+RESULTS_DIR="${1:-.}"
+BENCHMARK_NAME="${2:-unknown}"
+CSV_FILE="${3:-${RESULTS_DIR}/results.csv}"
+HTML_FILE="${RESULTS_DIR}/${BENCHMARK_NAME}_report.html"
+
+# Resolve to absolute path so tar works correctly
+RESULTS_DIR_ABS="$(cd "${RESULTS_DIR}" 2>/dev/null && pwd)" || RESULTS_DIR_ABS="${RESULTS_DIR}"
+
+# Build tarball in the parent directory first, then move it in.
+# This avoids "file changed as we read it" when tar archives a directory
+# that contains the tarball it's writing to.
+TARBALL_NAME="${BENCHMARK_NAME}_results.tar.gz"
+TARBALL_TMP="$(dirname "${RESULTS_DIR_ABS}")/${TARBALL_NAME}"
+TARBALL_FINAL="${RESULTS_DIR_ABS}/${TARBALL_NAME}"
+
+if [ ! -d "${RESULTS_DIR}" ]; then
+    echo "[ERROR] Results directory not found: ${RESULTS_DIR}"
+    exit 1
+fi
+
+echo "[REPORT] Generating report for: ${BENCHMARK_NAME}"
+echo "[REPORT] Results directory: ${RESULTS_DIR}"
+
+#################################################################################################
+# 1. HTML Report
+#################################################################################################
+
+echo "[REPORT] Generating HTML report..."
+
+# Pull summary data if available
+SUMMARY_FILE="${RESULTS_DIR}/sysinfo/SUMMARY.txt"
+SUMMARY_CONTENT=""
+if [ -f "${SUMMARY_FILE}" ]; then
+    SUMMARY_CONTENT=$(cat "${SUMMARY_FILE}" 2>/dev/null)
+fi
+
+# Pull CSV data if available
+CSV_CONTENT=""
+if [ -f "${CSV_FILE}" ]; then
+    CSV_CONTENT=$(cat "${CSV_FILE}" 2>/dev/null)
+fi
+
+cat > "${HTML_FILE}" << 'HTMLEOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OCP CMS Benchmark Report</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+            color: #333;
+        }
+        h1 { color: #1a1a2e; border-bottom: 3px solid #16213e; padding-bottom: 10px; }
+        h2 { color: #16213e; margin-top: 30px; }
+        .meta { background: #e8e8e8; padding: 15px; border-radius: 5px; margin: 15px 0; }
+        pre {
+            background: #1a1a2e;
+            color: #e0e0e0;
+            padding: 15px;
+            border-radius: 5px;
+            overflow-x: auto;
+            font-size: 13px;
+            line-height: 1.4;
+        }
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 15px 0;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 8px 12px;
+            text-align: left;
+        }
+        th { background: #16213e; color: white; }
+        tr:nth-child(even) { background: #f2f2f2; }
+        .footer { margin-top: 40px; color: #666; font-size: 12px; border-top: 1px solid #ddd; padding-top: 10px; }
+    </style>
+</head>
+<body>
+HTMLEOF
+
+# Inject dynamic content
+cat >> "${HTML_FILE}" << EOF
+    <h1>OCP SRV CMS - ${BENCHMARK_NAME} Benchmark Report</h1>
+    <div class="meta">
+        <strong>Generated:</strong> $(date -u '+%Y-%m-%dT%H:%M:%SZ')<br>
+        <strong>Hostname:</strong> $(hostname 2>/dev/null)<br>
+        <strong>Report Generator:</strong> v${REPORT_VERSION}
+    </div>
+EOF
+
+# System information section
+if [ -n "${SUMMARY_CONTENT}" ]; then
+    cat >> "${HTML_FILE}" << EOF
+    <h2>System Information</h2>
+    <pre>${SUMMARY_CONTENT}</pre>
+EOF
+fi
+
+# Results section
+if [ -n "${CSV_CONTENT}" ]; then
+    # Convert CSV to HTML table
+    echo "    <h2>Benchmark Results</h2>" >> "${HTML_FILE}"
+    echo "    <table>" >> "${HTML_FILE}"
+    first_line=true
+    while IFS= read -r line; do
+        if [ -z "${line}" ]; then continue; fi
+        echo "        <tr>" >> "${HTML_FILE}"
+        IFS=',' read -ra cells <<< "${line}"
+        for cell in "${cells[@]}"; do
+            # Strip surrounding quotes
+            cell=$(echo "${cell}" | sed 's/^"//;s/"$//')
+            if ${first_line}; then
+                echo "            <th>${cell}</th>" >> "${HTML_FILE}"
+            else
+                echo "            <td>${cell}</td>" >> "${HTML_FILE}"
+            fi
+        done
+        echo "        </tr>" >> "${HTML_FILE}"
+        first_line=false
+    done < "${CSV_FILE}"
+    echo "    </table>" >> "${HTML_FILE}"
+fi
+
+# Raw output section - list files
+echo "    <h2>Raw Output Files</h2>" >> "${HTML_FILE}"
+echo "    <pre>" >> "${HTML_FILE}"
+find "${RESULTS_DIR}" -type f | sort | while read -r f; do
+    # Show path relative to results dir
+    relpath="${f#${RESULTS_DIR}/}"
+    size=$(stat -c%s "${f}" 2>/dev/null || echo "?")
+    printf "%-60s %10s bytes\n" "${relpath}" "${size}" >> "${HTML_FILE}"
+done
+echo "    </pre>" >> "${HTML_FILE}"
+
+# Footer
+cat >> "${HTML_FILE}" << 'EOF'
+    <div class="footer">
+        OCP SRV CMS Benchmark Suite &bull; Report generated by generate_report.sh
+    </div>
+</body>
+</html>
+EOF
+
+echo "[REPORT] HTML report: ${HTML_FILE}"
+
+#################################################################################################
+# 2. Results Tarball
+#################################################################################################
+
+echo "[REPORT] Creating results tarball..."
+rm -f "${TARBALL_TMP}" 2>/dev/null
+tar czf "${TARBALL_TMP}" \
+    -C "$(dirname "${RESULTS_DIR_ABS}")" \
+    "$(basename "${RESULTS_DIR_ABS}")" \
+    2>/dev/null || echo "[WARN] Could not create tarball"
+
+# Move tarball into the results directory for the user
+if [ -f "${TARBALL_TMP}" ]; then
+    mv "${TARBALL_TMP}" "${TARBALL_FINAL}" 2>/dev/null || true
+fi
+
+echo "[REPORT] Tarball: ${TARBALL_FINAL}"
+
+#################################################################################################
+# Done
+#################################################################################################
+
+echo "[REPORT] Report generation complete."
+echo "[REPORT]   HTML:    ${HTML_FILE}"
+echo "[REPORT]   CSV:     ${CSV_FILE}"
+echo "[REPORT]   Tarball: ${TARBALL_FINAL}"


### PR DESCRIPTION
See Readme, and I need to go back and refactor stream and MLC, but this is better system info collection, formatting, log outputting and builds a common docker container base that every subsequent benchmark can build from so there aren't a ton of large containers floating around. Bumped to noble because library names are getting shuffled around, might as well start with less institutional cruft. 

Signed-off-by: Grant Mackey <grant.mackey@xcena.com>