### PR TITLE
Fix Heimdall cache benchmark in container runtime

### DIFF
--- a/src/container-runtime/software/heimdall/Dockerfile
+++ b/src/container-runtime/software/heimdall/Dockerfile
@@ -77,6 +77,10 @@ RUN git clone --branch ${HEIMDALL_VERSION} \
 
 WORKDIR /opt/heimdall
 
+# -- Apply container-runtime compatibility patches ----------------------------
+COPY patches/ /tmp/heimdall-patches/
+RUN git apply --unidiff-zero /tmp/heimdall-patches/*.patch
+
 # -- Install heimdall Python environment via uv -------------------------------
 RUN uv sync
 # Ensure pip is available inside the venv — heimdall's LLM install scripts
@@ -100,4 +104,3 @@ RUN chmod +x entrypoint.sh setup_env.sh parse_results.py
 RUN mkdir -p /opt/heimdall/container_results
 
 ENTRYPOINT ["/opt/heimdall/entrypoint.sh"]
-

--- a/src/container-runtime/software/heimdall/docker-compose.yml
+++ b/src/container-runtime/software/heimdall/docker-compose.yml
@@ -11,6 +11,10 @@ services:
     privileged: true
     volumes:
       - ${HOST_RESULTS_DIR:-./results}:/opt/heimdall/container_results
+      # Required for the cache benchmark, which builds and loads a kernel module
+      # against the host kernel from inside the privileged container.
+      - /lib/modules:/lib/modules:ro
+      - /usr/src:/usr/src:ro
     environment:
       # =================================================================
       # Benchmark Selection

--- a/src/container-runtime/software/heimdall/patches/0001-create-pointer-chasing-device-node.patch
+++ b/src/container-runtime/software/heimdall/patches/0001-create-pointer-chasing-device-node.patch
@@ -1,0 +1,50 @@
+diff --git a/benchmark/basic_performance/scripts/utils/batch_cache.py b/benchmark/basic_performance/scripts/utils/batch_cache.py
+index a2b71d2..b3ad709 100644
+--- a/benchmark/basic_performance/scripts/utils/batch_cache.py
++++ b/benchmark/basic_performance/scripts/utils/batch_cache.py
+@@ -46,0 +47,4 @@ from heimdall.utils.path import get_workspace_path
++DEVICE_NAME = "pointer_chasing"
++DEVICE_PATH = f"/dev/{DEVICE_NAME}"
++SYSFS_DEV_PATH = f"/sys/class/{DEVICE_NAME}/{DEVICE_NAME}/dev"
++
+@@ -104,0 +109,31 @@ def get_bin_path():
++def remove_device_node():
++    if os.path.exists(DEVICE_PATH):
++        run_as_sudo(f"rm -f {DEVICE_PATH}")
++
++
++def create_device_node():
++    for _ in range(20):
++        if os.path.exists(SYSFS_DEV_PATH):
++            break
++        time.sleep(0.1)
++    else:
++        logger.error(f"Device metadata {SYSFS_DEV_PATH} does not exist.")
++        sys.exit(1)
++
++    with open(SYSFS_DEV_PATH, "r", encoding="utf-8") as f:
++        major_minor = f.read().strip()
++
++    try:
++        major, minor = major_minor.split(":", 1)
++    except ValueError:
++        logger.error(f"Invalid device metadata in {SYSFS_DEV_PATH}: {major_minor}")
++        sys.exit(1)
++
++    remove_device_node()
++    result = run_as_sudo(f"mknod {DEVICE_PATH} c {major} {minor}")
++    if result is not None and result.exited != 0:
++        logger.error(f"Failed to create device node {DEVICE_PATH}.")
++        sys.exit(1)
++    run_as_sudo(f"chmod 666 {DEVICE_PATH}")
++
++
+@@ -142,0 +178 @@ def check_and_remove_module(module_name):
++    remove_device_node()
+@@ -163 +199,5 @@ def insert_module():
+-    run_as_sudo(cmd)
++    result = run_as_sudo(cmd)
++    if result is not None and result.exited != 0:
++        logger.error(f"Failed to insert module {module_path}.")
++        sys.exit(1)
++    create_device_node()


### PR DESCRIPTION
## Summary

This fixes the Heimdall `basic/cache` benchmark when running through the container runtime.

Two container-specific issues were observed:

1. The cache benchmark builds a kernel module against the running host kernel, but the container did not have access to the host kernel module/build tree.
2. After `pointer_chasing.ko` was loaded successfully, the userspace benchmark failed with:

```text
open: No such file or directory
```

The failing open is:

```cpp
open("/dev/pointer_chasing", O_RDWR)
```

Inside the container, the kernel module registers the character device and exposes its major/minor through sysfs, but `/dev/pointer_chasing` is not automatically created because the container does not have a normal host udev flow.

## Changes

- Mount host kernel build/module paths into the Heimdall container:

```yaml
/lib/modules:/lib/modules:ro
/usr/src:/usr/src:ro
```

- Add a Heimdall runtime patch applied during Docker build.
- After `insmod pointer_chasing.ko`, the patch:
  - reads major/minor from `/sys/class/pointer_chasing/pointer_chasing/dev`
  - creates `/dev/pointer_chasing` with `mknod`
  - applies permissive access with `chmod 666`
  - removes the device node during cleanup to avoid stale nodes

## Validation

Validated locally:

- `docker compose config`
- `git apply --check --unidiff-zero` against the upstream Heimdall checkout
- `git diff --check`

Observed behavior before the fix:

- Kernel module build failed without `/lib/modules/$(uname -r)/build`
- After mounting host kernel paths, module build/load succeeded
- Userspace then failed opening `/dev/pointer_chasing`

This patch addresses both container runtime issues.
