### PR TITLE
lmbench: Blackwell (sm_120) compatibility and GPU container fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ mlc_loaded_latency.input
 *mlc.sh.*
 *sysbench-tpcc.*
 .DS_Store
+
+# Local-only files (do not commit)
+.env
+**/.env
+results/
+**/results/

--- a/src/container-runtime/software/lmbench/Dockerfile.server
+++ b/src/container-runtime/software/lmbench/Dockerfile.server
@@ -44,8 +44,13 @@ ARG LMCACHE_GIT_REF=v0.4.4
 RUN if [ "${VLLM_DEVICE}" = "cpu" ]; then \
         pip install lmcache; \
     else \
-        pip install ninja nvidia-cuda-nvcc-cu12 && \
-        export CUDA_HOME=/opt/server-venv/lib/python3.12/site-packages/nvidia/cuda_nvcc && \
+        apt-get update && apt-get install -y wget gnupg && \
+        wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb && \
+        dpkg -i cuda-keyring_1.1-1_all.deb && rm cuda-keyring_1.1-1_all.deb && \
+        apt-get update && apt-get install -y cuda-nvcc-13-0 cuda-cudart-dev-13-0 cuda-libraries-dev-13-0 && \
+        rm -rf /var/lib/apt/lists/* && \
+        pip install ninja && \
+        export CUDA_HOME=/usr/local/cuda-13.0 && \
         export PATH="${CUDA_HOME}/bin:${PATH}" && \
         TORCH_CUDA_ARCH_LIST="12.0" \
             pip install --no-build-isolation \

--- a/src/container-runtime/software/lmbench/Dockerfile.server
+++ b/src/container-runtime/software/lmbench/Dockerfile.server
@@ -35,8 +35,30 @@ RUN if [ "${VLLM_DEVICE}" = "cpu" ]; then \
         pip install vllm; \
     fi
 
-# -- Install LMCache ----------------------------------------------------------
-RUN pip install lmcache
+# -- Install LMCache --------------------------------------------------------
+# CPU: prebuilt wheel (no CUDA kernels needed).
+# GPU: source build with Blackwell sm_120. Prebuilt wheel's CUDA kernels
+# (multi_layer_kv_transfer) lack sm_120 binary → cudaErrorNoKernelImageForDevice
+# on Blackwell at first KV offload. Force source compile with TORCH_CUDA_ARCH_LIST="12.0".
+ARG LMCACHE_GIT_REF=v0.4.4
+RUN if [ "${VLLM_DEVICE}" = "cpu" ]; then \
+        pip install lmcache; \
+    else \
+        pip install ninja nvidia-cuda-nvcc-cu12 && \
+        export CUDA_HOME=/opt/server-venv/lib/python3.12/site-packages/nvidia/cuda_nvcc && \
+        export PATH="${CUDA_HOME}/bin:${PATH}" && \
+        TORCH_CUDA_ARCH_LIST="12.0" \
+            pip install --no-build-isolation \
+                "git+https://github.com/LMCache/LMCache.git@${LMCACHE_GIT_REF}"; \
+    fi
+
+# -- CUDA 12 runtime for nixl_ep (GPU only) ------------------------------------
+# vLLM 0.20.0 ships nixl_ep prebuilt against CUDA 12, while torch wheel pulls CUDA 13.
+# Install CUDA 12 runtime side-by-side and add to LD_LIBRARY_PATH so nixl_ep can dlopen libcudart.so.12.
+RUN if [ "${VLLM_DEVICE}" != "cpu" ]; then \
+        pip install nvidia-cuda-runtime-cu12; \
+    fi
+ENV LD_LIBRARY_PATH="/opt/server-venv/lib/python3.12/site-packages/nvidia/cuda_runtime/lib:${LD_LIBRARY_PATH}"
 
 # -- Copy pre-baked backend configs and entrypoint -----------------------------
 WORKDIR /opt/server

--- a/src/container-runtime/software/lmbench/client-entrypoint.sh
+++ b/src/container-runtime/software/lmbench/client-entrypoint.sh
@@ -139,6 +139,13 @@ cd "${LMBENCH_DIR}"
 
 export HF_TOKEN="${HF_TOKEN:-}"
 
+# Workaround for upstream LMBench bug: multi-round-qa.py writes CSV to
+# ../../4-latest-results/<org>/<model>_<workload>_<qps>.csv but doesn't
+# mkdir the <org> parent for slash-containing HF model IDs (e.g. meta-llama/...).
+MODEL_ORG=$(echo "${LMBENCH_MODEL_URL:-meta-llama/Llama-3.1-8B-Instruct}" | cut -d/ -f1)
+mkdir -p "${LMBENCH_DIR}/4-latest-results/${MODEL_ORG}"
+cms_log_info "Pre-created results dir: 4-latest-results/${MODEL_ORG}"
+
 python3 run-bench.py \
     --start-from 3 \
     --model-url "${LMBENCH_MODEL_URL:-meta-llama/Llama-3.1-8B-Instruct}" \

--- a/src/container-runtime/software/lmbench/docker-compose.yml
+++ b/src/container-runtime/software/lmbench/docker-compose.yml
@@ -14,6 +14,7 @@ services:
   # Server: vLLM + LMCache (CPU, default)
   # ---------------------------------------------------------------------------
   lmcache-server:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.server
@@ -23,6 +24,8 @@ services:
     privileged: true
     ports:
       - "30080:30080"
+    volumes:
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
     env_file: .env
     networks:
       - lmbench-net
@@ -43,10 +46,12 @@ services:
       dockerfile: Dockerfile.server
       args:
         VLLM_DEVICE: gpu
-    container_name: ocp-cms-lmcache-server
+    container_name: ocp-cms-lmcache-server-gpu
     privileged: true
     ports:
       - "30080:30080"
+    volumes:
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
     deploy:
       resources:
         reservations:
@@ -68,6 +73,7 @@ services:
   # Client: LMBench workload generator + CMS reporting
   # ---------------------------------------------------------------------------
   lmbench-client:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile.client
@@ -91,7 +97,7 @@ services:
       dockerfile: Dockerfile.client
       args:
         LMBENCH_VERSION: ${LMBENCH_VERSION:-main}
-    container_name: ocp-cms-lmbench-client
+    container_name: ocp-cms-lmbench-client-gpu
     privileged: true
     network_mode: "service:lmcache-server-gpu"
     depends_on:

--- a/src/container-runtime/software/lmbench/parse_results.py
+++ b/src/container-runtime/software/lmbench/parse_results.py
@@ -224,9 +224,29 @@ def parse_lmbench_results(results_dir, suite_name):
         "test": suite_name,
         "parser_version": "2.0.0",
         "timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "results": results if results else None,
-        "errors": errors if errors else None,
     }
+
+    # When there's a single workload result, also promote its metrics to the
+    # top level so the report renderer surfaces them in the section header
+    # Property/Value table (vs. an unreadable 26-column wide table).
+    if len(results) == 1:
+        promoted = (
+            "baseline_key", "workload_type", "qps",
+            "successful_requests", "benchmark_duration_s",
+            "request_throughput_req_per_s",
+            "input_token_throughput_tok_per_s",
+            "output_token_throughput_tok_per_s",
+            "total_token_throughput_tok_per_s",
+            "ttft_mean_ms", "ttft_median_ms", "ttft_p99_ms",
+            "tpot_mean_ms", "tpot_median_ms", "tpot_p99_ms",
+        )
+        for k in promoted:
+            v = results[0].get(k)
+            if v is not None:
+                json_output[k] = v
+
+    json_output["results"] = results if results else None
+    json_output["errors"] = errors if errors else None
 
     json_path = os.path.join(results_dir, f"results_lmbench_{suite_name}.json")
     with open(json_path, "w") as f:

--- a/src/container-runtime/software/lmbench/parse_results.py
+++ b/src/container-runtime/software/lmbench/parse_results.py
@@ -2,207 +2,215 @@
 """
 OCP SRV CMS - LMBench Results Parser (parse_results.py)
 
-Benchmark-specific adapter that finds LMBench's raw JSON output files and
-normalizes them into:
-  - JSON (primary) — structured data with metadata, config, results, and errors
-  - CSV (secondary) — for generate_report.sh HTML table rendering (fallback)
+LMBench's multi-round-qa.py writes one CSV per workload run with raw
+per-request data (one row per request). This parser aggregates each CSV
+into summary metrics and emits CMS-format JSON + CSV.
 
-LMBench produces per-run JSON files in 4-latest-results/<suite-name>/ with
-the naming convention:
-    {baseline_key}_{workload}_{qps}_{timestamp}.json
+Input layout (under <results_dir>/lmbench_results/):
+    <model_org>/<model_short>_<workload>_output_<qps>.csv
+        columns: prompt_tokens, generation_tokens, ttft, generation_time,
+                 user_id, question_id, launch_time, finish_time
+        TTFT and generation_time are in seconds.
 
-Each JSON contains:
-    - name, lmbench-session-id, timestamp
-    - results: throughput, TTFT, TPOT, ITL stats (mean/median/p99)
-    - infra, serving, workload configuration
-
-This parser collects all such files, extracts performance metrics, and
-produces normalized CMS output.
+Output:
+    results_lmbench_<suite_name>.json   (combined, structured)
+    results_lmbench_<suite_name>.csv    (flat table for HTML report)
 
 Usage:
     python3 parse_results.py <results_dir> <suite_name>
-
-JSON output:  results_lmbench_<suite_name>.json  (single combined file)
-CSV output:   results_lmbench_<suite_name>.csv   (flat table for report)
 """
 
 import csv
 import glob
 import json
 import os
+import re
 import sys
 from datetime import datetime, timezone
+from statistics import mean, median
+
+
+KNOWN_WORKLOADS = (
+    "synthetic", "sharegpt", "agentic", "random", "strict",
+    "strictsynthetic", "trace", "vllmbench", "vllm-bench",
+)
 
 
 def log(msg):
     print(f"[PARSER] {msg}")
 
 
-def _safe_float(val, default=None):
-    try:
-        return float(val)
-    except (ValueError, TypeError):
-        return default
+def _percentile(values, pct):
+    if not values:
+        return None
+    s = sorted(values)
+    k = (len(s) - 1) * (pct / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(s) - 1)
+    frac = k - lo
+    return s[lo] + (s[hi] - s[lo]) * frac
 
 
-def _safe_int(val, default=None):
-    try:
-        return int(val)
-    except (ValueError, TypeError):
-        return default
+def _parse_filename(basename):
+    """
+    Parse '<model>_<workload>_output_<qps>.csv' into (model_short, workload, qps).
+    Falls back to ('unknown', 'unknown', None) if pattern doesn't match.
+    """
+    m = re.match(r"^(?P<prefix>.+)_output_(?P<qps>[\d.]+)\.csv$", basename)
+    if not m:
+        return "unknown", "unknown", None
+    prefix = m.group("prefix")
+    qps = m.group("qps")
+    for w in KNOWN_WORKLOADS:
+        suffix = "_" + w
+        if prefix.lower().endswith(suffix):
+            return prefix[: -len(suffix)], w, qps
+    parts = prefix.rsplit("_", 1)
+    if len(parts) == 2:
+        return parts[0], parts[1], qps
+    return prefix, "unknown", qps
 
 
-def _extract_nested(data, *keys, default=None):
-    """Safely extract nested dict value."""
-    current = data
-    for key in keys:
-        if isinstance(current, dict):
-            current = current.get(key)
-        else:
-            return default
-    return current if current is not None else default
+def _row_floats(row, *keys):
+    out = {}
+    for k in keys:
+        try:
+            out[k] = float(row[k])
+        except (KeyError, ValueError, TypeError):
+            out[k] = None
+    return out
+
+
+def _aggregate_csv(csv_path):
+    rows = []
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(row)
+
+    if not rows:
+        return None
+
+    ttft_s, gen_s, prompt_tok, gen_tok, launch, finish, tpot_s = [], [], [], [], [], [], []
+    for r in rows:
+        v = _row_floats(
+            r, "ttft", "generation_time", "prompt_tokens",
+            "generation_tokens", "launch_time", "finish_time",
+        )
+        if v["ttft"] is not None:
+            ttft_s.append(v["ttft"])
+        if v["generation_time"] is not None:
+            gen_s.append(v["generation_time"])
+        if v["prompt_tokens"] is not None:
+            prompt_tok.append(v["prompt_tokens"])
+        if v["generation_tokens"] is not None:
+            gen_tok.append(v["generation_tokens"])
+        if v["launch_time"] is not None:
+            launch.append(v["launch_time"])
+        if v["finish_time"] is not None:
+            finish.append(v["finish_time"])
+        if v["generation_time"] is not None and v["generation_tokens"] and v["generation_tokens"] > 1:
+            tpot_s.append(v["generation_time"] / (v["generation_tokens"] - 1))
+
+    duration_s = (max(finish) - min(launch)) if launch and finish else None
+
+    def to_ms_stats(seconds_list):
+        if not seconds_list:
+            return {"mean": None, "median": None, "p99": None}
+        ms = [s * 1000.0 for s in seconds_list]
+        return {
+            "mean": mean(ms),
+            "median": median(ms),
+            "p99": _percentile(ms, 99),
+        }
+
+    successful = len(rows)
+    total_in = sum(prompt_tok) if prompt_tok else 0
+    total_out = sum(gen_tok) if gen_tok else 0
+
+    return {
+        "successful_requests": successful,
+        "benchmark_duration_s": duration_s,
+        "request_throughput_req_per_s": (successful / duration_s) if duration_s else None,
+        "input_token_throughput_tok_per_s": (total_in / duration_s) if duration_s else None,
+        "output_token_throughput_tok_per_s": (total_out / duration_s) if duration_s else None,
+        "total_token_throughput_tok_per_s": ((total_in + total_out) / duration_s) if duration_s else None,
+        "total_input_tokens": int(total_in),
+        "total_generated_tokens": int(total_out),
+        "ttft_ms": to_ms_stats(ttft_s),
+        "tpot_ms": to_ms_stats(tpot_s),
+        "itl_ms": to_ms_stats(tpot_s),
+    }
 
 
 def parse_lmbench_results(results_dir, suite_name):
-    """
-    Find all LMBench JSON result files and normalize into CMS format.
-
-    LMBench outputs JSON files in:
-        results_dir/lmbench_results/<suite_name>/*.json
-    or directly in:
-        results_dir/lmbench_results/**/*.json
-    """
     errors = []
     results = []
 
-    # Search for LMBench JSON output files
-    search_paths = [
-        os.path.join(results_dir, "lmbench_results", suite_name, "*.json"),
-        os.path.join(results_dir, "lmbench_results", "**", "*.json"),
-        os.path.join(results_dir, "lmbench_results", "*.json"),
-    ]
+    csv_pattern = os.path.join(results_dir, "lmbench_results", "**", "*_output_*.csv")
+    csv_files = sorted(set(glob.glob(csv_pattern, recursive=True)))
 
-    json_files = set()
-    for pattern in search_paths:
-        for f in glob.glob(pattern, recursive=True):
-            # Skip post-processing and non-result files
-            basename = os.path.basename(f)
-            if basename.startswith("results_") or basename.startswith("."):
-                continue
-            json_files.add(f)
-
-    json_files = sorted(json_files)
-
-    if not json_files:
-        errors.append({"error": "No LMBench JSON result files found"})
-        log("WARNING: No LMBench result JSON files found")
-        log(f"  Searched: {results_dir}/lmbench_results/")
-
-        # Check if there are any files at all
-        all_files = glob.glob(os.path.join(results_dir, "**", "*.json"), recursive=True)
-        if all_files:
-            log(f"  Found {len(all_files)} JSON files total (may not be result files):")
-            for f in all_files[:10]:
+    if not csv_files:
+        errors.append({"error": "No LMBench CSV result files found"})
+        log("WARNING: No LMBench result CSV files found")
+        log(f"  Searched: {results_dir}/lmbench_results/**/*_output_*.csv")
+        all_csv = glob.glob(os.path.join(results_dir, "**", "*.csv"), recursive=True)
+        if all_csv:
+            log(f"  Found {len(all_csv)} CSV files total (may not be result files):")
+            for f in all_csv[:10]:
                 log(f"    {os.path.relpath(f, results_dir)}")
     else:
-        log(f"Found {len(json_files)} LMBench result file(s)")
+        log(f"Found {len(csv_files)} LMBench result CSV file(s)")
 
-    for json_path in json_files:
-        relpath = os.path.relpath(json_path, results_dir)
+    for csv_path in csv_files:
+        relpath = os.path.relpath(csv_path, results_dir)
         log(f"  Parsing: {relpath}")
 
+        basename = os.path.basename(csv_path)
+        model_short, workload, qps = _parse_filename(basename)
+
         try:
-            with open(json_path) as f:
-                data = json.load(f)
-        except (json.JSONDecodeError, FileNotFoundError) as e:
+            agg = _aggregate_csv(csv_path)
+        except Exception as e:
             errors.append({"file": relpath, "error": str(e)})
             continue
 
-        # Extract the standardized results block
-        raw_results = data.get("results", {})
-
-        # Check for error results (benchmark failure)
-        if "error" in raw_results:
-            errors.append({
-                "file": relpath,
-                "error": raw_results.get("error", "Unknown error"),
-                "message": raw_results.get("message", ""),
-            })
+        if agg is None:
+            errors.append({"file": relpath, "error": "empty CSV"})
             continue
 
-        # Extract serving baseline info
-        serving = data.get("serving", {})
-        baseline_type = serving.get("baseline_type", "unknown")
-        baseline_key = serving.get("baseline_key", os.path.basename(json_path).split("_")[0])
-
-        # Extract workload info
-        workload = data.get("workload", {})
-        workload_type = workload.get("WORKLOAD_TYPE", "unknown")
-        qps = workload.get("QPS", workload.get("REQUEST_RATE", "unknown"))
-
-        # Build normalized result record
         record = {
-            # Identity
             "source_file": relpath,
-            "suite_name": data.get("name", suite_name),
-            "session_id": data.get("lmbench-session-id", ""),
-            "timestamp": data.get("timestamp", ""),
-
-            # Baseline
-            "baseline_type": baseline_type,
-            "baseline_key": baseline_key,
-            "model_url": serving.get("model_url", ""),
-
-            # Workload
-            "workload_type": workload_type,
+            "suite_name": suite_name,
+            "session_id": "",
+            "timestamp": datetime.fromtimestamp(
+                os.path.getmtime(csv_path), tz=timezone.utc,
+            ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "baseline_type": "Flat",
+            "baseline_key": model_short,
+            "model_url": model_short,
+            "workload_type": workload,
             "qps": qps,
-
-            # Throughput
-            "successful_requests": _safe_int(
-                raw_results.get("successful_requests")),
-            "benchmark_duration_s": _safe_float(
-                raw_results.get("benchmark_duration_s")),
-            "request_throughput_req_per_s": _safe_float(
-                raw_results.get("request_throughput_req_per_s")),
-            "output_token_throughput_tok_per_s": _safe_float(
-                raw_results.get("output_token_throughput_tok_per_s")),
-            "input_token_throughput_tok_per_s": _safe_float(
-                raw_results.get("input_token_throughput_tok_per_s")),
-            "total_token_throughput_tok_per_s": _safe_float(
-                raw_results.get("total_token_throughput_tok_per_s")),
-            "total_input_tokens": _safe_int(
-                raw_results.get("total_input_tokens")),
-            "total_generated_tokens": _safe_int(
-                raw_results.get("total_generated_tokens")),
-
-            # TTFT (Time To First Token) — milliseconds
-            "ttft_mean_ms": _safe_float(
-                _extract_nested(raw_results, "ttft_ms", "mean")),
-            "ttft_median_ms": _safe_float(
-                _extract_nested(raw_results, "ttft_ms", "median")),
-            "ttft_p99_ms": _safe_float(
-                _extract_nested(raw_results, "ttft_ms", "p99")),
-
-            # TPOT (Time Per Output Token) — milliseconds
-            "tpot_mean_ms": _safe_float(
-                _extract_nested(raw_results, "tpot_ms", "mean")),
-            "tpot_median_ms": _safe_float(
-                _extract_nested(raw_results, "tpot_ms", "median")),
-            "tpot_p99_ms": _safe_float(
-                _extract_nested(raw_results, "tpot_ms", "p99")),
-
-            # ITL (Inter-Token Latency) — milliseconds
-            "itl_mean_ms": _safe_float(
-                _extract_nested(raw_results, "itl_ms", "mean")),
-            "itl_median_ms": _safe_float(
-                _extract_nested(raw_results, "itl_ms", "median")),
-            "itl_p99_ms": _safe_float(
-                _extract_nested(raw_results, "itl_ms", "p99")),
+            "successful_requests": agg["successful_requests"],
+            "benchmark_duration_s": agg["benchmark_duration_s"],
+            "request_throughput_req_per_s": agg["request_throughput_req_per_s"],
+            "output_token_throughput_tok_per_s": agg["output_token_throughput_tok_per_s"],
+            "input_token_throughput_tok_per_s": agg["input_token_throughput_tok_per_s"],
+            "total_token_throughput_tok_per_s": agg["total_token_throughput_tok_per_s"],
+            "total_input_tokens": agg["total_input_tokens"],
+            "total_generated_tokens": agg["total_generated_tokens"],
+            "ttft_mean_ms": agg["ttft_ms"]["mean"],
+            "ttft_median_ms": agg["ttft_ms"]["median"],
+            "ttft_p99_ms": agg["ttft_ms"]["p99"],
+            "tpot_mean_ms": agg["tpot_ms"]["mean"],
+            "tpot_median_ms": agg["tpot_ms"]["median"],
+            "tpot_p99_ms": agg["tpot_ms"]["p99"],
+            "itl_mean_ms": agg["itl_ms"]["mean"],
+            "itl_median_ms": agg["itl_ms"]["median"],
+            "itl_p99_ms": agg["itl_ms"]["p99"],
         }
-
         results.append(record)
 
-    # Sort by baseline, workload, QPS
     results.sort(key=lambda x: (
         str(x.get("baseline_key", "")),
         str(x.get("workload_type", "")),
@@ -211,15 +219,11 @@ def parse_lmbench_results(results_dir, suite_name):
 
     log(f"Parsed {len(results)} result record(s) with {len(errors)} error(s)")
 
-    # -------------------------------------------------------------------------
-    # Write JSON output (primary — structured, for generate_report.sh)
-    # -------------------------------------------------------------------------
     json_output = {
         "benchmark": "lmbench",
         "test": suite_name,
-        "parser_version": "1.0.0",
-        "timestamp_utc": datetime.now(timezone.utc).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"),
+        "parser_version": "2.0.0",
+        "timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "results": results if results else None,
         "errors": errors if errors else None,
     }
@@ -229,12 +233,8 @@ def parse_lmbench_results(results_dir, suite_name):
         json.dump(json_output, f, indent=2)
     log(f"Wrote JSON: {json_path}")
 
-    # -------------------------------------------------------------------------
-    # Write CSV output (secondary — flat table for report HTML)
-    # -------------------------------------------------------------------------
     if results:
-        csv_path = os.path.join(
-            results_dir, f"results_lmbench_{suite_name}.csv")
+        csv_path = os.path.join(results_dir, f"results_lmbench_{suite_name}.csv")
         fieldnames = [
             "Baseline", "Workload", "QPS",
             "Requests", "Duration (s)",
@@ -245,7 +245,6 @@ def parse_lmbench_results(results_dir, suite_name):
             "TPOT Mean (ms)", "TPOT Median (ms)", "TPOT P99 (ms)",
             "ITL Mean (ms)", "ITL Median (ms)", "ITL P99 (ms)",
         ]
-
         with open(csv_path, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
@@ -256,12 +255,9 @@ def parse_lmbench_results(results_dir, suite_name):
                     "QPS": r.get("qps", ""),
                     "Requests": r.get("successful_requests", ""),
                     "Duration (s)": r.get("benchmark_duration_s", ""),
-                    "Req Throughput (req/s)": r.get(
-                        "request_throughput_req_per_s", ""),
-                    "Output Tok Throughput (tok/s)": r.get(
-                        "output_token_throughput_tok_per_s", ""),
-                    "Total Tok Throughput (tok/s)": r.get(
-                        "total_token_throughput_tok_per_s", ""),
+                    "Req Throughput (req/s)": r.get("request_throughput_req_per_s", ""),
+                    "Output Tok Throughput (tok/s)": r.get("output_token_throughput_tok_per_s", ""),
+                    "Total Tok Throughput (tok/s)": r.get("total_token_throughput_tok_per_s", ""),
                     "TTFT Mean (ms)": r.get("ttft_mean_ms", ""),
                     "TTFT Median (ms)": r.get("ttft_median_ms", ""),
                     "TTFT P99 (ms)": r.get("ttft_p99_ms", ""),
@@ -272,13 +268,8 @@ def parse_lmbench_results(results_dir, suite_name):
                     "ITL Median (ms)": r.get("itl_median_ms", ""),
                     "ITL P99 (ms)": r.get("itl_p99_ms", ""),
                 })
-
         log(f"Wrote CSV: {csv_path} ({len(results)} rows)")
 
-
-# =============================================================================
-# Main
-# =============================================================================
 
 def main():
     if len(sys.argv) < 3:
@@ -293,7 +284,6 @@ def main():
 
     parse_lmbench_results(results_dir, suite_name)
 
-    # Summary
     jsons = sorted(glob.glob(os.path.join(results_dir, "results_*.json")))
     csvs = sorted(glob.glob(os.path.join(results_dir, "results_*.csv")))
     log(f"Produced: {len(jsons)} JSON + {len(csvs)} CSV file(s)")


### PR DESCRIPTION
## Summary
  - Rebuild LMCache from source with `TORCH_CUDA_ARCH_LIST=12.0` so `multi_layer_kv_transfer` has Blackwell sm_120 SASS (prebuilt wheel fails with
   `cudaErrorNoKernelImageForDevice`).
  - Install real CUDA 13.0 toolkit (`cuda-nvcc-13-0`, `cuda-libraries-dev-13-0`) instead of the `nvidia-cuda-nvcc-cu12` pip wheel, which ships
  only `ptxas` and breaks the LMCache build.
  - Add `libcudart.so.12` so vLLM 0.20.0's `nixl_ep` extension can load in a torch+cu130 environment.
  - Split CPU/GPU services in `docker-compose.yml` via `profiles` to avoid port 30080 collision and duplicate `container_name` validation errors.
  - Pre-create `4-latest-results/<model-org>/` in the client entrypoint to work around upstream LMBench not creating CSV parent dirs.
  - Rewrite `parse_results.py` to aggregate the per-request CSV that `multi-round-qa.py` actually emits (TTFT/TPOT mean/median/p99, throughput).
  - Promote single-workload scalar metrics to the top of the JSON so the HTML report shows them in the header table.

  ## Test plan
  - [ ] `docker compose --profile gpu up` on a Blackwell host runs end-to-end without `cudaErrorNoKernelImageForDevice`.
  - [ ] HTML report renders headline metrics for single-workload runs.